### PR TITLE
Tools tab: run the measurements without a terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ update dialog; standalone users can watch GitHub releases.
 - Recognitions from a history scan are excluded from the delay figures rather than silently
   averaged in; they lag their event by weeks and would wreck every median. The count of
   what was dropped is shown.
+- **Corrected: there is no 3-second floor.** README and the notification blueprint said the
+  name takes 3 seconds at the very best, "because that is how long Frigate takes to produce
+  the first snapshot". The new tool made it checkable, and 18% of recognitions land below
+  that, the fastest in 0.8s. The old figure was the *median* of first attempts in an older
+  sample, written up as a physical limit. Both measurement paths — the log-based script and
+  the history — now agree: median 8-9s, fastest around 1s, and the floor varies per event.
+  Clocks were compared between Frigate and the container first; they match to the second.
+- The history no longer prints a similarity of 1.0 as if it meant something. Every such
+  entry was a face that had since been assigned, so it is one of that person's reference
+  photos and matches itself. It now reads "now assigned: <name>", without a number.
+- `retry_seconds: 1.2` (down from 2.5) is confirmed to have worked: attempt 2 went from a
+  median of 6.5s to 4.0s.
 
 ## 0.21.0 — 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ update dialog; standalone users can watch GitHub releases.
   photos and matches itself. It now reads "now assigned: <name>", without a number.
 - `retry_seconds: 1.2` (down from 2.5) is confirmed to have worked: attempt 2 went from a
   median of 6.5s to 4.0s.
+- **Two long-standing bugs in the background jobs**, found while reviewing the new one and
+  fixed for the history scan and the calibration analysis as well:
+  - A failing import inside a worker killed the thread before the `finally` that clears the
+    running flag. The job then stayed "running" forever and every later start answered `409
+    already running` until a service restart — with that message as the only clue, pointing
+    at everything except the real cause. Verified by breaking the import on purpose.
+  - Starting a job checked the running flag and set it in two separate steps, so two
+    simultaneous starts could both get past the guard. Now held under one lock.
 
 ## 0.21.0 — 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to FaceID. The Home Assistant app shows this file in the
 update dialog; standalone users can watch GitHub releases.
 
+## 0.22.0 — 2026-09-02
+
+- **A Tools tab with the measurements that used to need a terminal.** Off by default;
+  switch it on under Settings → *Does it work?*. It runs three analyses that so far only
+  existed as scripts: how fast a recognition is, how well each person is covered, and why
+  events yield no usable face.
+- This is not a convenience wrapper around the scripts — it could not be. `scripts/` is not
+  in the app image at all (the Dockerfile ships `app/` and `static/`), and the delay
+  measurement read `journalctl`, which does not exist in a container without systemd. For
+  anyone running FaceID as a Home Assistant app, those analyses were unreachable, not just
+  inconvenient.
+- The delay measurement therefore uses a different source than the script: the history
+  instead of the log. The event's start time is in the Frigate event id anyway, and the
+  moment the name went out is in the history entry — so it needs neither the log nor camera
+  access, and answers instantly.
+- Recognitions from a history scan are excluded from the delay figures rather than silently
+  averaged in; they lag their event by weeks and would wreck every median. The count of
+  what was dropped is shown.
+
 ## 0.21.0 — 2026-09-01
 
 - **Camera filter on the review queue and the history, and a choice of how many history

--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ tools built on the same models (Immich, CompreFace) sit in the same range.
 | 480 | ~107 ms |
 | 320 | ~60 ms |
 
-Lower values find small and distant faces less reliably, so trade it against
-`scripts/why-no-face.py` rather than by feel.
+Lower values find small and distant faces less reliably, so trade it against the
+*Why do events yield no face?* tool (Tools tab, or `scripts/why-no-face.py`) rather than
+by feel.
 
 If ~650 MB is genuinely too much, the only real reduction is a smaller model family
 (`buffalo_s`, MobileFaceNet instead of ResNet-50, roughly a third of the memory) at the
@@ -329,8 +330,8 @@ box-less snapshots: **[docs/camera-bridge.md](docs/camera-bridge.md)**.
 ## Calibrating the threshold
 
 The defaults are deliberately cautious, and on a real gallery that caution turned out to
-be expensive. Measure yours rather than guessing — `scripts/measure-recognition.py` and
-`scripts/coverage.py` produce the numbers.
+be expensive. Measure yours rather than guessing — the Tools tab produces the numbers
+without a terminal, as do `scripts/measure-recognition.py` and `scripts/coverage.py`.
 
 On a 128-photo household gallery the separation was far wider than the defaults assume:
 
@@ -384,6 +385,28 @@ work?* reports the ceiling for both cases, and refuses to suggest lowering anyth
 finds a misassignment.
 
 ## Measuring instead of guessing
+
+### Without a terminal: the Tools tab
+
+Switch it on under **Settings → Does it work? → show the Tools tab**. It runs the same
+analyses in the service itself and shows them as tables:
+
+| Tool | Answers | Cost |
+|---|---|---|
+| How fast is a recognition? | delay from the start of the event to the published name, per attempt and camera | instant, reads the history |
+| How well is each person covered? | angles, cameras, day and night per person, and what photo is concretely missing | re-reads every reference photo |
+| Why do events yield no face? | no face at all / too small / detector unsure, per camera | downloads one snapshot per event |
+
+This is not a wrapper around the scripts below, because it could not be: `scripts/` is not
+part of the app image at all, and the delay measurement there reads `journalctl`, which does
+not exist in a container without systemd. If you run FaceID as a Home Assistant app, the tab
+is the only way to get these numbers.
+
+The delay figures therefore come from the history rather than the log, which also means they
+need no camera access. Recognitions produced by a history scan are excluded instead of being
+averaged in — they lag their event by weeks — and the tab says how many it dropped.
+
+### With a terminal: the scripts
 
 Three scripts answer the questions that otherwise invite guesswork:
 
@@ -552,9 +575,11 @@ If you use a Frigate notification blueprint (SgtBatten's is the common one), you
 probably noticed the name never appears in it. Two measured reasons:
 
 - **The name is not ready yet.** The blueprint fires when the event starts; FaceID first
-  needs a snapshot to exist, a face in it, and a match. Over 132 real recognitions the name
-  was ready after a **median of 7 seconds**, and 3 seconds at the very best — that is how
-  long Frigate itself takes to produce a first snapshot.
+  needs a snapshot to exist, a face in it, and a match. Over 155 real recognitions on one
+  household setup the name was ready after a **median of 8 seconds**, the fastest in one.
+  What sets the floor is Frigate's time to a first usable snapshot, and that varies a lot —
+  it is not a fixed few seconds. Measure your own in FaceID's **Tools** tab (switch it on
+  under Settings → *Does it work?*); the numbers depend on your cameras and your hardware.
 - **Waiting can help — but often does not, for a different reason than I first published.**
   ⚠️ An earlier version of this section claimed Frigate never announces the name over MQTT.
   That was wrong: the test behind it ran against an *already finished* event, where nothing

--- a/app/history.py
+++ b/app/history.py
@@ -21,6 +21,8 @@ from pathlib import Path
 import cv2
 import numpy as np
 
+from .analysis import SELF_HIT
+
 log = logging.getLogger("faceid.history")
 
 
@@ -99,7 +101,6 @@ class History:
                         # dass genau dieser Ausschnitt inzwischen selbst ein Referenzfoto
                         # ist: das Bild vergleicht sich mit sich selbst. Als Guetemass
                         # waere das eine Scheinaussage, also wird es getrennt ausgewiesen.
-                        from .analysis import SELF_HIT
                         item["now"] = {"person": name, "score": round(float(score), 3),
                                        "self": float(score) >= SELF_HIT}
                 except Exception:

--- a/app/history.py
+++ b/app/history.py
@@ -95,7 +95,13 @@ class History:
                     # "heute waere das X" anzuzeigen waere genau die irrefuehrende Angabe,
                     # gegen die dieser Verlauf gebaut wurde.
                     if name and name != item.get("person") and score >= threshold:
-                        item["now"] = {"person": name, "score": round(float(score), 3)}
+                        # Ein Wert von 1.0 heisst nicht "wird sicher erkannt", sondern
+                        # dass genau dieser Ausschnitt inzwischen selbst ein Referenzfoto
+                        # ist: das Bild vergleicht sich mit sich selbst. Als Guetemass
+                        # waere das eine Scheinaussage, also wird es getrennt ausgewiesen.
+                        from .analysis import SELF_HIT
+                        item["now"] = {"person": name, "score": round(float(score), 3),
+                                       "self": float(score) >= SELF_HIT}
                 except Exception:
                     pass
             out.append(item)

--- a/app/tools.py
+++ b/app/tools.py
@@ -140,6 +140,10 @@ def _ir_cameras(frigate, cfg, days: int = 7, sample: int = 8) -> set:
     """
     if frigate is None:
         return set()
+    # Nur Kameras, die FaceID ueberhaupt verarbeitet. Sonst raet die Auswertung zu einer
+    # IR-Aufnahme an einer Kamera, die gar nicht mehr in Betrieb ist — genau das ist hier
+    # passiert, nachdem eine Kamera aus der Liste geflogen war.
+    wanted = set(cfg.get("faceid", {}).get("cameras") or [])
     try:
         from zoneinfo import ZoneInfo
         tz = ZoneInfo(cfg.get("faceid", {}).get("timezone", "Europe/Berlin"))
@@ -150,7 +154,7 @@ def _ir_cameras(frigate, cfg, days: int = 7, sample: int = 8) -> set:
     out, seen = set(), Counter()
     for ev in evs:
         cam = ev.get("camera")
-        if not cam or seen[cam] >= sample:
+        if not cam or seen[cam] >= sample or (wanted and cam not in wanted):
             continue
         hour = datetime.datetime.fromtimestamp(ev["start_time"], tz).hour
         if not (hour >= 21 or hour <= 5):
@@ -323,9 +327,12 @@ def why_no_face(engine, frigate, cfg, days: float = 3.0, progress=None) -> dict:
         cam = ev.get("camera") or "?"
         per_cam.setdefault(cam, Counter())[reason] += 1
 
+    # Bewusst ueber ALLE Kameras, nicht nur die verarbeiteten: die Frage lautet ja
+    # gerade, ob sich eine Kamera lohnt. Welche in Betrieb sind, steht daneben.
+    wanted = set(cfg["faceid"].get("cameras") or [])
     cams = [{"camera": c, "events": sum(r.values()), "ok": r[OK],
              "no_face": r[NO_DETECTION], "too_small": r[TOO_SMALL],
-             "uncertain": r[UNCERTAIN]}
+             "uncertain": r[UNCERTAIN], "used": not wanted or c in wanted}
             for c, r in sorted(per_cam.items(), key=lambda kv: -sum(kv[1].values()))]
     return {"days": days, "events": len(events), "min_face_px": min_px,
             "reasons": dict(reasons), "cameras": cams,

--- a/app/tools.py
+++ b/app/tools.py
@@ -1,0 +1,332 @@
+"""Auswertungen, die es bisher nur als Skript in ``scripts/`` gab.
+
+Das ist keine Bequemlichkeitskopie. Wer FaceID als Home-Assistant-App betreibt, hat
+``scripts/`` überhaupt nicht — das Dockerfile kopiert nur ``app/`` und ``static/`` —
+und ``measure-delay.py`` liest ``journalctl``, das es in einem Container ohne systemd
+gar nicht gibt. Für genau die Leute ohne Shell waren diese Auswertungen also nie
+erreichbar. Hier laufen sie serverseitig und brauchen weder das eine noch das andere.
+
+Die Verzögerungsmessung kommt deshalb auch aus einer anderen Quelle als das Skript:
+nicht aus dem Log, sondern aus dem Verlauf. Der Ereignisbeginn steckt ohnehin in der
+Frigate-Ereignis-ID (``1788331891.926818-xyuhgt``), der Meldezeitpunkt im Eintrag.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import time
+from collections import Counter
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+FRONTAL, HALF = 0.55, 0.25   # Symmetrie-Grenzen frontal / halb / Profil
+NIGHT_SAT = 12               # mittlere HSV-Sättigung darunter = Graustufen/IR
+
+# Erkennungen aus dem Verlaufs-Scan liegen Wochen hinter ihrem Ereignis. Als
+# Verzögerung gezählt würden sie jeden Median zerlegen, also fliegen sie raus —
+# aber sichtbar, nicht stillschweigend.
+LIVE_MAX_DELAY = 300.0
+
+
+def _stats(vals: list) -> dict:
+    """Median und Ränder. Der Mittelwert wäre hier irreführend: ein einzelnes
+    Ereignis, das erst nach zwei Minuten ein Gesicht hergibt, verschiebt ihn weit."""
+    if not vals:
+        return {"n": 0}
+    s = sorted(vals)
+    return {"n": len(s), "median": round(float(np.median(s)), 1),
+            "p10": round(float(np.percentile(s, 10)), 1),
+            "p90": round(float(np.percentile(s, 90)), 1),
+            "min": round(s[0], 1), "max": round(s[-1], 1)}
+
+
+def delay(history_dir: Path, days: float = 0.0) -> dict:
+    """Wie lange dauert es vom Ereignisbeginn bis zum gemeldeten Namen?
+
+    Untergrenze ist nicht FaceID, sondern Frigate: vor dem ersten Schnappschuss gibt
+    es nichts zu erkennen. Die Aufschlüsselung nach Versuch zeigt genau das — Versuch 1
+    ist die Zeit bis zum ersten brauchbaren Bild, jeder weitere kostet den Abstand.
+    """
+    if not history_dir.is_dir():
+        return {"error": "no history yet — recognitions are recorded from now on"}
+
+    after = time.time() - days * 86400 if days else 0.0
+    rows, late = [], 0
+    for jf in history_dir.glob("*.json"):
+        try:
+            h = json.loads(jf.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        ev, ts = h.get("event_id"), h.get("ts")
+        if not ev or not ts or float(ts) < after:
+            continue
+        try:
+            start = float(str(ev).split("-")[0])
+        except ValueError:
+            continue
+        d = float(ts) - start
+        if d < 0:
+            continue
+        if d > LIVE_MAX_DELAY:
+            late += 1
+            continue
+        rows.append({"d": d, "ts": float(ts), "cam": h.get("camera") or "?",
+                     "attempt": h.get("attempt"), "person": h.get("person")})
+
+    if not rows:
+        return {"n": 0, "skipped_late": late,
+                "note": "no recognitions in this window"}
+
+    by_attempt, by_cam, by_day = {}, {}, {}
+    for r in rows:
+        if r["attempt"] is not None:
+            by_attempt.setdefault(int(r["attempt"]), []).append(r["d"])
+        by_cam.setdefault(r["cam"], []).append(r["d"])
+        day = datetime.date.fromtimestamp(r["ts"]).isoformat()
+        by_day.setdefault(day, []).append(r["d"])
+
+    vals = [r["d"] for r in rows]
+    return {
+        **_stats(vals),
+        "days": days,
+        "skipped_late": late,
+        "first": min(r["ts"] for r in rows),
+        "last": max(r["ts"] for r in rows),
+        "by_attempt": [{"attempt": k, **_stats(v)} for k, v in sorted(by_attempt.items())],
+        "by_camera": [{"camera": k, **_stats(v)}
+                      for k, v in sorted(by_cam.items(), key=lambda kv: -len(kv[1]))],
+        "by_day": [{"day": k, **_stats(v)} for k, v in sorted(by_day.items())],
+    }
+
+
+def _yaw_symmetry(kps):
+    """1.0 = frontal, gegen 0 = Profil. Nase relativ zu den beiden Augen."""
+    k = np.asarray(kps, dtype=np.float32)
+    if k.shape[0] < 5:
+        return None
+    axis = k[1] - k[0]
+    d = float(np.linalg.norm(axis))
+    if d < 1e-3:
+        return None
+    axis = axis / d
+    a = abs(float(np.dot(k[2] - k[0], axis)))
+    b = abs(float(np.dot(k[2] - k[1], axis)))
+    return min(a, b) / max(a, b) if max(a, b) > 1e-3 else 0.0
+
+
+def _match(gal, e, top_k, drop_slug, drop_idx):
+    best_slug, best = None, 0.0
+    for slug, g in gal.items():
+        sims = g["emb"] @ e
+        if slug == drop_slug:
+            sims = np.delete(sims, drop_idx)
+        if not len(sims):
+            continue
+        k = min(top_k, len(sims))
+        s = float(np.mean(np.sort(sims)[-k:]))
+        if s > best:
+            best_slug, best = slug, s
+    return best_slug, best
+
+
+def _ir_cameras(frigate, cfg, days: int = 7, sample: int = 8) -> set:
+    """Kameras, deren Nachtaufnahmen in Graustufen kommen (echte IR-Umschaltung).
+
+    Wo bei Bewegung Licht angeht, nimmt die Kamera auch nachts in Farbe auf — dort ist
+    eine fehlende IR-Referenz kein Mangel. Aus echten Ereignissen ermittelt statt aus
+    der Galerie, sonst übersähe man genau die Lücke, die man sucht.
+    """
+    if frigate is None:
+        return set()
+    try:
+        from zoneinfo import ZoneInfo
+        tz = ZoneInfo(cfg.get("faceid", {}).get("timezone", "Europe/Berlin"))
+        evs = frigate.events(label="person", has_snapshot=1, limit=300,
+                             after=time.time() - days * 86400) or []
+    except Exception:
+        return set()
+    out, seen = set(), Counter()
+    for ev in evs:
+        cam = ev.get("camera")
+        if not cam or seen[cam] >= sample:
+            continue
+        hour = datetime.datetime.fromtimestamp(ev["start_time"], tz).hour
+        if not (hour >= 21 or hour <= 5):
+            continue
+        img = frigate.snapshot(ev["id"], crop=True)
+        if img is None:
+            continue
+        seen[cam] += 1
+        if float(np.mean(cv2.cvtColor(img, cv2.COLOR_BGR2HSV)[:, :, 1])) < NIGHT_SAT:
+            out.add(cam)
+    return out
+
+
+def coverage(data_dir: Path, engine, frigate, cfg, progress=None) -> dict:
+    """Wie gut ist jede Person abgedeckt — und welche Aufnahme fehlt ihr konkret?
+
+    Mehr Fotos heißen nicht bessere Erkennung, entscheidend ist die Bandbreite:
+    Blickwinkel, Kameras, Tag und Nacht. Der Selbst-Test am Ende ist bewusst hart und
+    bei kleinen Sammlungen systematisch pessimistisch — bei fünf vielfältigen Fotos
+    muss eines gegen vier ganz andere Situationen bestehen. Eine niedrige Rate heißt
+    „die Fotos stützen einander wenig", nicht „die Person wird nicht erkannt".
+    """
+    from .engine import FaceEngine
+
+    thr = float(cfg["faceid"].get("match_threshold", 0.5))
+    top_k = max(1, int(cfg["faceid"].get("match_top_k", 3)))
+
+    gal = {}
+    for d in sorted(p for p in (data_dir / "persons").glob("*") if p.is_dir()):
+        try:
+            emb = np.load(d / "embeddings.npy").astype(np.float32)
+            meta = json.loads((d / "meta.json").read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if emb.ndim != 2 or not len(emb):
+            continue
+        gal[d.name] = {"name": meta.get("name", d.name), "emb": emb,
+                       "files": meta.get("files", []), "dir": d,
+                       "sources": meta.get("sources", {})}
+    if not gal:
+        return {"error": "no gallery yet — assign a few faces first"}
+
+    ir_cams = _ir_cameras(frigate, cfg)
+    total = sum(len(g["files"]) for g in gal.values())
+    done = 0
+    people, advice = [], []
+
+    for slug, g in gal.items():
+        emb, n = g["emb"], len(g["emb"])
+        sims = emb @ emb.T
+        np.fill_diagonal(sims, np.nan)
+        diversity = float(np.nanmean(sims)) if n > 1 else None
+
+        cams, angles, night = Counter(), [], 0
+        for fn in g["files"]:
+            done += 1
+            if progress:
+                progress(done, total)
+            src = g["sources"].get(fn) or {}
+            cams[src.get("camera") or "?"] += 1
+            img = cv2.imread(str(g["dir"] / fn))
+            if img is None:
+                continue
+            if float(np.mean(cv2.cvtColor(img, cv2.COLOR_BGR2HSV)[:, :, 1])) < NIGHT_SAT:
+                night += 1
+            f = FaceEngine.best_face(engine.faces(img), min_px=20, min_det=0.4)
+            if f is not None:
+                s = _yaw_symmetry(f.kps)
+                if s is not None:
+                    angles.append(s)
+
+        front = sum(1 for a in angles if a >= FRONTAL)
+        half = sum(1 for a in angles if HALF <= a < FRONTAL)
+        prof = sum(1 for a in angles if a < HALF)
+
+        hit = 0
+        for i in range(n):
+            got, sc = _match(gal, emb[i], top_k, slug, i)
+            if got == slug and sc >= thr:
+                hit += 1
+        rate = 100 * hit // n if n else 0
+
+        known = {c: k for c, k in cams.items() if c != "?"}
+        people.append({"name": g["name"], "photos": n,
+                       "diversity": None if diversity is None else round(diversity, 2),
+                       "frontal": front, "half": half, "profile": prof,
+                       "greyscale": night, "self_test": rate,
+                       "cameras": [{"camera": c, "n": k}
+                                   for c, k in sorted(known.items(), key=lambda x: -x[1])],
+                       "unknown_camera": cams.get("?", 0)})
+
+        missing = []
+        if n < 5:
+            missing.append("too few photos")
+        if not front:
+            missing.append("no frontal shot")
+        if ir_cams and not night and (known.keys() & ir_cams):
+            missing.append("no IR night shot")
+        if len(known) == 1 and n >= 3:
+            missing.append(f"only one camera ({next(iter(known))})")
+        if diversity is not None and diversity > 0.55:
+            missing.append(f"photos look very alike ({diversity:.2f})")
+        if n >= 8 and rate < 40:
+            missing.append(f"photos barely support each other (self test {rate}%)")
+        if missing:
+            advice.append({"name": g["name"], "self_test": rate, "missing": missing})
+
+    people.sort(key=lambda p: p["name"].lower())
+    advice.sort(key=lambda a: a["self_test"])
+    return {"threshold": thr, "top_k": top_k, "people": people, "advice": advice,
+            "ir_cameras": sorted(ir_cams)}
+
+
+NO_DETECTION, TOO_SMALL, UNCERTAIN, OK = "no face", "too small", "uncertain", "ok"
+
+
+def why_no_face(engine, frigate, cfg, days: float = 3.0, progress=None) -> dict:
+    """Warum liefern so viele Ereignisse kein brauchbares Gesicht?
+
+    Trennt die drei Gründe, die sich sonst zu einem „wird nicht erkannt" vermischen:
+    gar kein Gesicht im Bild, eines das zu klein ist, oder eines das die Erkennung
+    selbst nicht sicher genug findet. Erst die Aufschlüsselung nach Kamera zeigt, ob
+    ein Standort etwas taugt — oder nur Rücken und Hinterköpfe liefert.
+    """
+    from .engine import FaceEngine
+
+    if frigate is None:
+        return {"error": "no Frigate connection configured"}
+    min_px = int(cfg["faceid"].get("min_face_px", 48))
+    min_det = 0.65
+
+    after = time.time() - days * 86400
+    events, before = [], None
+    while True:
+        params = {"label": "person", "has_snapshot": 1, "limit": 100, "after": after}
+        if before:
+            params["before"] = before
+        batch = frigate.events(**params)
+        if not batch:
+            break
+        events.extend(batch)
+        before = batch[-1]["start_time"]
+        if len(batch) < 100:
+            break
+
+    reasons, per_cam, widths = Counter(), {}, []
+    for i, ev in enumerate(events):
+        if progress:
+            progress(i + 1, len(events))
+        img = frigate.snapshot(ev["id"], crop=True)
+        if img is None:
+            reasons["no snapshot"] += 1
+            continue
+        faces = engine.faces(img)
+        if not len(faces):
+            reason, w, det = NO_DETECTION, 0.0, 0.0
+        else:
+            ws = [float(f.bbox[2] - f.bbox[0]) for f in faces]
+            hs = [float(f.bbox[3] - f.bbox[1]) for f in faces]
+            big = [f for f, w, h in zip(faces, ws, hs) if w >= min_px and h >= min_px]
+            if not big:
+                reason, w, det = TOO_SMALL, max(ws), max(float(f.det_score) for f in faces)
+            else:
+                det = max(float(f.det_score) for f in big)
+                w = max(ws)
+                reason = UNCERTAIN if det < min_det else OK
+        reasons[reason] += 1
+        if w:
+            widths.append(w)
+        cam = ev.get("camera") or "?"
+        per_cam.setdefault(cam, Counter())[reason] += 1
+
+    cams = [{"camera": c, "events": sum(r.values()), "ok": r[OK],
+             "no_face": r[NO_DETECTION], "too_small": r[TOO_SMALL],
+             "uncertain": r[UNCERTAIN]}
+            for c, r in sorted(per_cam.items(), key=lambda kv: -sum(kv[1].values()))]
+    return {"days": days, "events": len(events), "min_face_px": min_px,
+            "reasons": dict(reasons), "cameras": cams,
+            "face_width": _stats(widths) if widths else {"n": 0}}

--- a/app/tools.py
+++ b/app/tools.py
@@ -279,8 +279,6 @@ def why_no_face(engine, frigate, cfg, days: float = 3.0, progress=None) -> dict:
     selbst nicht sicher genug findet. Erst die Aufschlüsselung nach Kamera zeigt, ob
     ein Standort etwas taugt — oder nur Rücken und Hinterköpfe liefert.
     """
-    from .engine import FaceEngine
-
     if frigate is None:
         return {"error": "no Frigate connection configured"}
     min_px = int(cfg["faceid"].get("min_face_px", 48))

--- a/app/webui.py
+++ b/app/webui.py
@@ -549,6 +549,77 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
     def analysis_status():
         return dict(analysis_state)
 
+    # ---- Werkzeuge -------------------------------------------------------------
+    # Dieselben Auswertungen wie in scripts/, nur ohne Shell. Noetig, weil scripts/
+    # gar nicht im App-Image liegt (das Dockerfile kopiert app/ und static/) und die
+    # Verzoegerungsmessung dort journalctl braeuchte, das es im Container nicht gibt.
+    TOOL_SPECS = [
+        {"id": "delay", "label": "How fast is a recognition?",
+         "about": "Time from the start of the event to the published name, split by "
+                  "attempt — attempt 1 is really Frigate's time to a usable snapshot. "
+                  "Reads the history, so it needs no camera access and is instant.",
+         "days": [0, 1, 3, 7, 14], "days_label": "period", "needs": "history"},
+        {"id": "coverage", "label": "How well is each person covered?",
+         "about": "Angles, cameras, day and night per person — and what photo is "
+                  "concretely missing. Re-reads every reference photo, so it takes a "
+                  "while on a large gallery.",
+         "days": [], "needs": "gallery"},
+        {"id": "why-no-face", "label": "Why do events yield no face?",
+         "about": "Separates the three reasons that otherwise blur into 'not "
+                  "recognised': no face in the picture at all, one too small, or one "
+                  "the detector is unsure about. Downloads a snapshot per event.",
+         "days": [1, 3, 7], "days_label": "look back", "needs": "frigate"},
+    ]
+    tool_state = {t["id"]: {"running": False, "processed": 0, "total": 0,
+                            "result": None} for t in TOOL_SPECS}
+
+    class ToolBody(BaseModel):
+        days: float = 3.0
+
+    @app.get("/api/tools")
+    def tools_list():
+        return {"tools": TOOL_SPECS, "state": tool_state}
+
+    @app.post("/api/tools/{tid}")
+    def start_tool(tid: str, body: ToolBody):
+        st = tool_state.get(tid)
+        if st is None:
+            raise HTTPException(404, "unknown tool")
+        if st["running"]:
+            raise HTTPException(409, "already running")
+        days = max(0.0, min(float(body.days), 30.0))
+        st.update(running=True, processed=0, total=0, result=None)
+
+        def worker():
+            from . import tools as t
+            prog = lambda i, n: st.update(processed=i, total=n)
+            try:
+                if tid == "delay":
+                    h = getattr(processor, "history", None)
+                    st["result"] = ({"error": "history is disabled (history_keep: 0)"}
+                                    if h is None else t.delay(h.dir, days=days))
+                elif tid == "coverage":
+                    st["result"] = t.coverage(data_dir, engine, processor.frigate, cfg,
+                                              progress=prog)
+                else:
+                    st["result"] = t.why_no_face(engine, processor.frigate, cfg,
+                                                 days=days, progress=prog)
+            except Exception as e:
+                log.exception("tool %s failed", tid)
+                st["result"] = {"error": str(e)}
+            finally:
+                st["running"] = False
+
+        threading.Thread(target=worker, daemon=True, name=f"faceid-tool-{tid}").start()
+        return {"started": True, "days": days}
+
+    @app.get("/api/tools/{tid}")
+    def tool_status(tid: str):
+        st = tool_state.get(tid)
+        if st is None:
+            raise HTTPException(404, "unknown tool")
+        return dict(st)
+
     @app.get("/api/backups")
     def backups():
         """Gespeicherte Backups auflisten — wer FaceID als App betreibt, kommt sonst gar

--- a/app/webui.py
+++ b/app/webui.py
@@ -371,8 +371,8 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
             backfill_state.update(processed=i, total=total)
 
         def worker():
-            from .backfill import run_backfill
             try:
+                from .backfill import run_backfill
                 stats = run_backfill(
                     engine, gallery, processor.frigate, cfg["frigate"]["url"], days=days,
                     tag=bool(cfg["faceid"].get("set_sub_label", True)),
@@ -540,8 +540,8 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
             analysis_state.update(running=True, processed=0, total=0, result=None)
 
         def worker():
-            from . import analysis
             try:
+                from . import analysis
                 analysis_state["result"] = analysis.run(
                     data_dir, engine, processor.frigate, cfg, days=days,
                     progress=lambda i, t: analysis_state.update(processed=i, total=t))
@@ -601,9 +601,12 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
             st.update(running=True, processed=0, total=0, result=None)
 
         def worker():
-            from . import tools as t
-            prog = lambda i, n: st.update(processed=i, total=n)
+            # Der Import gehoert INS try: schlaegt er fehl, stirbt der Thread sonst vor
+            # dem finally, "running" bliebe fuer immer True und das Werkzeug waere bis
+            # zum Neustart tot — mit "already running" als einziger Auskunft.
             try:
+                from . import tools as t
+                prog = lambda i, n: st.update(processed=i, total=n)
                 if tid == "delay":
                     h = getattr(processor, "history", None)
                     st["result"] = ({"error": "history is disabled (history_keep: 0)"}

--- a/app/webui.py
+++ b/app/webui.py
@@ -347,6 +347,13 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
             gallery.discard_unknown(uid)
         return {"ok": True}
 
+    # Pruefen und Setzen von "running" muss zusammen passieren. FastAPI fuehrt
+    # synchrone Endpunkte in einem Threadpool aus, und zwischen der Abfrage und dem
+    # Setzen liegt eine Zuweisung — dort kann Python den Thread wechseln. Zwei
+    # gleichzeitige Starts kaemen sonst beide durch die 409-Sperre und wuerden in
+    # denselben Zustand schreiben. Die Sperre haelt nur den Check-and-Set, nie den Lauf.
+    job_lock = threading.Lock()
+
     backfill_state = {"running": False, "processed": 0, "total": 0, "result": None, "days": 0}
 
     class BackfillBody(BaseModel):
@@ -354,10 +361,11 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
 
     @app.post("/api/backfill")
     def start_backfill(body: BackfillBody):
-        if backfill_state["running"]:
-            raise HTTPException(409, "History scan already running")
         days = max(1, min(int(body.days), 60))
-        backfill_state.update(running=True, processed=0, total=0, result=None, days=days)
+        with job_lock:
+            if backfill_state["running"]:
+                raise HTTPException(409, "History scan already running")
+            backfill_state.update(running=True, processed=0, total=0, result=None, days=days)
 
         def progress(i, total):
             backfill_state.update(processed=i, total=total)
@@ -525,10 +533,11 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
     def start_analysis(body: AnalysisBody):
         """Kalibrierungs-Auswertung anstossen — dieselbe Rechnung wie die Skripte,
         aber ohne Shell, damit App-Nutzer sie ueberhaupt ausfuehren koennen."""
-        if analysis_state["running"]:
-            raise HTTPException(409, "analysis already running")
         days = max(0.0, min(float(body.days), 30.0))
-        analysis_state.update(running=True, processed=0, total=0, result=None)
+        with job_lock:
+            if analysis_state["running"]:
+                raise HTTPException(409, "analysis already running")
+            analysis_state.update(running=True, processed=0, total=0, result=None)
 
         def worker():
             from . import analysis
@@ -585,10 +594,11 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
         st = tool_state.get(tid)
         if st is None:
             raise HTTPException(404, "unknown tool")
-        if st["running"]:
-            raise HTTPException(409, "already running")
         days = max(0.0, min(float(body.days), 30.0))
-        st.update(running=True, processed=0, total=0, result=None)
+        with job_lock:
+            if st["running"]:
+                raise HTTPException(409, "already running")
+            st.update(running=True, processed=0, total=0, result=None)
 
         def worker():
             from . import tools as t

--- a/blueprints/faceid-name-the-person.yaml
+++ b/blueprints/faceid-name-the-person.yaml
@@ -8,9 +8,10 @@ blueprint:
 
     **Why this is needed.** A Frigate notification blueprint fires when the event starts.
     FaceID needs a moment longer: it has to wait for a snapshot to exist, find a face in it
-    and match it. Measured over 132 real recognitions on one household setup, the name is
-    ready after a median of 7 seconds — 3 seconds at the very best, because that is how long
-    Frigate itself takes to produce the first snapshot.
+    and match it. Measured over 155 real recognitions on one household setup, the name is
+    ready after a median of 8 seconds, the fastest of them in one. What sets the floor is how
+    long Frigate takes to produce a usable snapshot, which varies widely from event to event.
+    Your own figures are in FaceID's Tools tab.
 
 
     **Correction (2026-08-31).** An earlier version of this text claimed Frigate never

--- a/faceid-addon/CHANGELOG.md
+++ b/faceid-addon/CHANGELOG.md
@@ -21,6 +21,18 @@ update dialog; standalone users can watch GitHub releases.
 - Recognitions from a history scan are excluded from the delay figures rather than silently
   averaged in; they lag their event by weeks and would wreck every median. The count of
   what was dropped is shown.
+- **Corrected: there is no 3-second floor.** README and the notification blueprint said the
+  name takes 3 seconds at the very best, "because that is how long Frigate takes to produce
+  the first snapshot". The new tool made it checkable, and 18% of recognitions land below
+  that, the fastest in 0.8s. The old figure was the *median* of first attempts in an older
+  sample, written up as a physical limit. Both measurement paths — the log-based script and
+  the history — now agree: median 8-9s, fastest around 1s, and the floor varies per event.
+  Clocks were compared between Frigate and the container first; they match to the second.
+- The history no longer prints a similarity of 1.0 as if it meant something. Every such
+  entry was a face that had since been assigned, so it is one of that person's reference
+  photos and matches itself. It now reads "now assigned: <name>", without a number.
+- `retry_seconds: 1.2` (down from 2.5) is confirmed to have worked: attempt 2 went from a
+  median of 6.5s to 4.0s.
 
 ## 0.21.0 — 2026-09-01
 

--- a/faceid-addon/CHANGELOG.md
+++ b/faceid-addon/CHANGELOG.md
@@ -33,6 +33,14 @@ update dialog; standalone users can watch GitHub releases.
   photos and matches itself. It now reads "now assigned: <name>", without a number.
 - `retry_seconds: 1.2` (down from 2.5) is confirmed to have worked: attempt 2 went from a
   median of 6.5s to 4.0s.
+- **Two long-standing bugs in the background jobs**, found while reviewing the new one and
+  fixed for the history scan and the calibration analysis as well:
+  - A failing import inside a worker killed the thread before the `finally` that clears the
+    running flag. The job then stayed "running" forever and every later start answered `409
+    already running` until a service restart — with that message as the only clue, pointing
+    at everything except the real cause. Verified by breaking the import on purpose.
+  - Starting a job checked the running flag and set it in two separate steps, so two
+    simultaneous starts could both get past the guard. Now held under one lock.
 
 ## 0.21.0 — 2026-09-01
 

--- a/faceid-addon/CHANGELOG.md
+++ b/faceid-addon/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to FaceID. The Home Assistant app shows this file in the
 update dialog; standalone users can watch GitHub releases.
 
+## 0.22.0 — 2026-09-02
+
+- **A Tools tab with the measurements that used to need a terminal.** Off by default;
+  switch it on under Settings → *Does it work?*. It runs three analyses that so far only
+  existed as scripts: how fast a recognition is, how well each person is covered, and why
+  events yield no usable face.
+- This is not a convenience wrapper around the scripts — it could not be. `scripts/` is not
+  in the app image at all (the Dockerfile ships `app/` and `static/`), and the delay
+  measurement read `journalctl`, which does not exist in a container without systemd. For
+  anyone running FaceID as a Home Assistant app, those analyses were unreachable, not just
+  inconvenient.
+- The delay measurement therefore uses a different source than the script: the history
+  instead of the log. The event's start time is in the Frigate event id anyway, and the
+  moment the name went out is in the history entry — so it needs neither the log nor camera
+  access, and answers instantly.
+- Recognitions from a history scan are excluded from the delay figures rather than silently
+  averaged in; they lag their event by weeks and would wreck every median. The count of
+  what was dropped is shown.
+
 ## 0.21.0 — 2026-09-01
 
 - **Camera filter on the review queue and the history, and a choice of how many history

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -21,6 +21,8 @@ from pathlib import Path
 import cv2
 import numpy as np
 
+from .analysis import SELF_HIT
+
 log = logging.getLogger("faceid.history")
 
 
@@ -99,7 +101,6 @@ class History:
                         # dass genau dieser Ausschnitt inzwischen selbst ein Referenzfoto
                         # ist: das Bild vergleicht sich mit sich selbst. Als Guetemass
                         # waere das eine Scheinaussage, also wird es getrennt ausgewiesen.
-                        from .analysis import SELF_HIT
                         item["now"] = {"person": name, "score": round(float(score), 3),
                                        "self": float(score) >= SELF_HIT}
                 except Exception:

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -95,7 +95,13 @@ class History:
                     # "heute waere das X" anzuzeigen waere genau die irrefuehrende Angabe,
                     # gegen die dieser Verlauf gebaut wurde.
                     if name and name != item.get("person") and score >= threshold:
-                        item["now"] = {"person": name, "score": round(float(score), 3)}
+                        # Ein Wert von 1.0 heisst nicht "wird sicher erkannt", sondern
+                        # dass genau dieser Ausschnitt inzwischen selbst ein Referenzfoto
+                        # ist: das Bild vergleicht sich mit sich selbst. Als Guetemass
+                        # waere das eine Scheinaussage, also wird es getrennt ausgewiesen.
+                        from .analysis import SELF_HIT
+                        item["now"] = {"person": name, "score": round(float(score), 3),
+                                       "self": float(score) >= SELF_HIT}
                 except Exception:
                     pass
             out.append(item)

--- a/faceid-addon/app/tools.py
+++ b/faceid-addon/app/tools.py
@@ -140,6 +140,10 @@ def _ir_cameras(frigate, cfg, days: int = 7, sample: int = 8) -> set:
     """
     if frigate is None:
         return set()
+    # Nur Kameras, die FaceID ueberhaupt verarbeitet. Sonst raet die Auswertung zu einer
+    # IR-Aufnahme an einer Kamera, die gar nicht mehr in Betrieb ist — genau das ist hier
+    # passiert, nachdem eine Kamera aus der Liste geflogen war.
+    wanted = set(cfg.get("faceid", {}).get("cameras") or [])
     try:
         from zoneinfo import ZoneInfo
         tz = ZoneInfo(cfg.get("faceid", {}).get("timezone", "Europe/Berlin"))
@@ -150,7 +154,7 @@ def _ir_cameras(frigate, cfg, days: int = 7, sample: int = 8) -> set:
     out, seen = set(), Counter()
     for ev in evs:
         cam = ev.get("camera")
-        if not cam or seen[cam] >= sample:
+        if not cam or seen[cam] >= sample or (wanted and cam not in wanted):
             continue
         hour = datetime.datetime.fromtimestamp(ev["start_time"], tz).hour
         if not (hour >= 21 or hour <= 5):
@@ -323,9 +327,12 @@ def why_no_face(engine, frigate, cfg, days: float = 3.0, progress=None) -> dict:
         cam = ev.get("camera") or "?"
         per_cam.setdefault(cam, Counter())[reason] += 1
 
+    # Bewusst ueber ALLE Kameras, nicht nur die verarbeiteten: die Frage lautet ja
+    # gerade, ob sich eine Kamera lohnt. Welche in Betrieb sind, steht daneben.
+    wanted = set(cfg["faceid"].get("cameras") or [])
     cams = [{"camera": c, "events": sum(r.values()), "ok": r[OK],
              "no_face": r[NO_DETECTION], "too_small": r[TOO_SMALL],
-             "uncertain": r[UNCERTAIN]}
+             "uncertain": r[UNCERTAIN], "used": not wanted or c in wanted}
             for c, r in sorted(per_cam.items(), key=lambda kv: -sum(kv[1].values()))]
     return {"days": days, "events": len(events), "min_face_px": min_px,
             "reasons": dict(reasons), "cameras": cams,

--- a/faceid-addon/app/tools.py
+++ b/faceid-addon/app/tools.py
@@ -1,0 +1,332 @@
+"""Auswertungen, die es bisher nur als Skript in ``scripts/`` gab.
+
+Das ist keine Bequemlichkeitskopie. Wer FaceID als Home-Assistant-App betreibt, hat
+``scripts/`` überhaupt nicht — das Dockerfile kopiert nur ``app/`` und ``static/`` —
+und ``measure-delay.py`` liest ``journalctl``, das es in einem Container ohne systemd
+gar nicht gibt. Für genau die Leute ohne Shell waren diese Auswertungen also nie
+erreichbar. Hier laufen sie serverseitig und brauchen weder das eine noch das andere.
+
+Die Verzögerungsmessung kommt deshalb auch aus einer anderen Quelle als das Skript:
+nicht aus dem Log, sondern aus dem Verlauf. Der Ereignisbeginn steckt ohnehin in der
+Frigate-Ereignis-ID (``1788331891.926818-xyuhgt``), der Meldezeitpunkt im Eintrag.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import time
+from collections import Counter
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+FRONTAL, HALF = 0.55, 0.25   # Symmetrie-Grenzen frontal / halb / Profil
+NIGHT_SAT = 12               # mittlere HSV-Sättigung darunter = Graustufen/IR
+
+# Erkennungen aus dem Verlaufs-Scan liegen Wochen hinter ihrem Ereignis. Als
+# Verzögerung gezählt würden sie jeden Median zerlegen, also fliegen sie raus —
+# aber sichtbar, nicht stillschweigend.
+LIVE_MAX_DELAY = 300.0
+
+
+def _stats(vals: list) -> dict:
+    """Median und Ränder. Der Mittelwert wäre hier irreführend: ein einzelnes
+    Ereignis, das erst nach zwei Minuten ein Gesicht hergibt, verschiebt ihn weit."""
+    if not vals:
+        return {"n": 0}
+    s = sorted(vals)
+    return {"n": len(s), "median": round(float(np.median(s)), 1),
+            "p10": round(float(np.percentile(s, 10)), 1),
+            "p90": round(float(np.percentile(s, 90)), 1),
+            "min": round(s[0], 1), "max": round(s[-1], 1)}
+
+
+def delay(history_dir: Path, days: float = 0.0) -> dict:
+    """Wie lange dauert es vom Ereignisbeginn bis zum gemeldeten Namen?
+
+    Untergrenze ist nicht FaceID, sondern Frigate: vor dem ersten Schnappschuss gibt
+    es nichts zu erkennen. Die Aufschlüsselung nach Versuch zeigt genau das — Versuch 1
+    ist die Zeit bis zum ersten brauchbaren Bild, jeder weitere kostet den Abstand.
+    """
+    if not history_dir.is_dir():
+        return {"error": "no history yet — recognitions are recorded from now on"}
+
+    after = time.time() - days * 86400 if days else 0.0
+    rows, late = [], 0
+    for jf in history_dir.glob("*.json"):
+        try:
+            h = json.loads(jf.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        ev, ts = h.get("event_id"), h.get("ts")
+        if not ev or not ts or float(ts) < after:
+            continue
+        try:
+            start = float(str(ev).split("-")[0])
+        except ValueError:
+            continue
+        d = float(ts) - start
+        if d < 0:
+            continue
+        if d > LIVE_MAX_DELAY:
+            late += 1
+            continue
+        rows.append({"d": d, "ts": float(ts), "cam": h.get("camera") or "?",
+                     "attempt": h.get("attempt"), "person": h.get("person")})
+
+    if not rows:
+        return {"n": 0, "skipped_late": late,
+                "note": "no recognitions in this window"}
+
+    by_attempt, by_cam, by_day = {}, {}, {}
+    for r in rows:
+        if r["attempt"] is not None:
+            by_attempt.setdefault(int(r["attempt"]), []).append(r["d"])
+        by_cam.setdefault(r["cam"], []).append(r["d"])
+        day = datetime.date.fromtimestamp(r["ts"]).isoformat()
+        by_day.setdefault(day, []).append(r["d"])
+
+    vals = [r["d"] for r in rows]
+    return {
+        **_stats(vals),
+        "days": days,
+        "skipped_late": late,
+        "first": min(r["ts"] for r in rows),
+        "last": max(r["ts"] for r in rows),
+        "by_attempt": [{"attempt": k, **_stats(v)} for k, v in sorted(by_attempt.items())],
+        "by_camera": [{"camera": k, **_stats(v)}
+                      for k, v in sorted(by_cam.items(), key=lambda kv: -len(kv[1]))],
+        "by_day": [{"day": k, **_stats(v)} for k, v in sorted(by_day.items())],
+    }
+
+
+def _yaw_symmetry(kps):
+    """1.0 = frontal, gegen 0 = Profil. Nase relativ zu den beiden Augen."""
+    k = np.asarray(kps, dtype=np.float32)
+    if k.shape[0] < 5:
+        return None
+    axis = k[1] - k[0]
+    d = float(np.linalg.norm(axis))
+    if d < 1e-3:
+        return None
+    axis = axis / d
+    a = abs(float(np.dot(k[2] - k[0], axis)))
+    b = abs(float(np.dot(k[2] - k[1], axis)))
+    return min(a, b) / max(a, b) if max(a, b) > 1e-3 else 0.0
+
+
+def _match(gal, e, top_k, drop_slug, drop_idx):
+    best_slug, best = None, 0.0
+    for slug, g in gal.items():
+        sims = g["emb"] @ e
+        if slug == drop_slug:
+            sims = np.delete(sims, drop_idx)
+        if not len(sims):
+            continue
+        k = min(top_k, len(sims))
+        s = float(np.mean(np.sort(sims)[-k:]))
+        if s > best:
+            best_slug, best = slug, s
+    return best_slug, best
+
+
+def _ir_cameras(frigate, cfg, days: int = 7, sample: int = 8) -> set:
+    """Kameras, deren Nachtaufnahmen in Graustufen kommen (echte IR-Umschaltung).
+
+    Wo bei Bewegung Licht angeht, nimmt die Kamera auch nachts in Farbe auf — dort ist
+    eine fehlende IR-Referenz kein Mangel. Aus echten Ereignissen ermittelt statt aus
+    der Galerie, sonst übersähe man genau die Lücke, die man sucht.
+    """
+    if frigate is None:
+        return set()
+    try:
+        from zoneinfo import ZoneInfo
+        tz = ZoneInfo(cfg.get("faceid", {}).get("timezone", "Europe/Berlin"))
+        evs = frigate.events(label="person", has_snapshot=1, limit=300,
+                             after=time.time() - days * 86400) or []
+    except Exception:
+        return set()
+    out, seen = set(), Counter()
+    for ev in evs:
+        cam = ev.get("camera")
+        if not cam or seen[cam] >= sample:
+            continue
+        hour = datetime.datetime.fromtimestamp(ev["start_time"], tz).hour
+        if not (hour >= 21 or hour <= 5):
+            continue
+        img = frigate.snapshot(ev["id"], crop=True)
+        if img is None:
+            continue
+        seen[cam] += 1
+        if float(np.mean(cv2.cvtColor(img, cv2.COLOR_BGR2HSV)[:, :, 1])) < NIGHT_SAT:
+            out.add(cam)
+    return out
+
+
+def coverage(data_dir: Path, engine, frigate, cfg, progress=None) -> dict:
+    """Wie gut ist jede Person abgedeckt — und welche Aufnahme fehlt ihr konkret?
+
+    Mehr Fotos heißen nicht bessere Erkennung, entscheidend ist die Bandbreite:
+    Blickwinkel, Kameras, Tag und Nacht. Der Selbst-Test am Ende ist bewusst hart und
+    bei kleinen Sammlungen systematisch pessimistisch — bei fünf vielfältigen Fotos
+    muss eines gegen vier ganz andere Situationen bestehen. Eine niedrige Rate heißt
+    „die Fotos stützen einander wenig", nicht „die Person wird nicht erkannt".
+    """
+    from .engine import FaceEngine
+
+    thr = float(cfg["faceid"].get("match_threshold", 0.5))
+    top_k = max(1, int(cfg["faceid"].get("match_top_k", 3)))
+
+    gal = {}
+    for d in sorted(p for p in (data_dir / "persons").glob("*") if p.is_dir()):
+        try:
+            emb = np.load(d / "embeddings.npy").astype(np.float32)
+            meta = json.loads((d / "meta.json").read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        if emb.ndim != 2 or not len(emb):
+            continue
+        gal[d.name] = {"name": meta.get("name", d.name), "emb": emb,
+                       "files": meta.get("files", []), "dir": d,
+                       "sources": meta.get("sources", {})}
+    if not gal:
+        return {"error": "no gallery yet — assign a few faces first"}
+
+    ir_cams = _ir_cameras(frigate, cfg)
+    total = sum(len(g["files"]) for g in gal.values())
+    done = 0
+    people, advice = [], []
+
+    for slug, g in gal.items():
+        emb, n = g["emb"], len(g["emb"])
+        sims = emb @ emb.T
+        np.fill_diagonal(sims, np.nan)
+        diversity = float(np.nanmean(sims)) if n > 1 else None
+
+        cams, angles, night = Counter(), [], 0
+        for fn in g["files"]:
+            done += 1
+            if progress:
+                progress(done, total)
+            src = g["sources"].get(fn) or {}
+            cams[src.get("camera") or "?"] += 1
+            img = cv2.imread(str(g["dir"] / fn))
+            if img is None:
+                continue
+            if float(np.mean(cv2.cvtColor(img, cv2.COLOR_BGR2HSV)[:, :, 1])) < NIGHT_SAT:
+                night += 1
+            f = FaceEngine.best_face(engine.faces(img), min_px=20, min_det=0.4)
+            if f is not None:
+                s = _yaw_symmetry(f.kps)
+                if s is not None:
+                    angles.append(s)
+
+        front = sum(1 for a in angles if a >= FRONTAL)
+        half = sum(1 for a in angles if HALF <= a < FRONTAL)
+        prof = sum(1 for a in angles if a < HALF)
+
+        hit = 0
+        for i in range(n):
+            got, sc = _match(gal, emb[i], top_k, slug, i)
+            if got == slug and sc >= thr:
+                hit += 1
+        rate = 100 * hit // n if n else 0
+
+        known = {c: k for c, k in cams.items() if c != "?"}
+        people.append({"name": g["name"], "photos": n,
+                       "diversity": None if diversity is None else round(diversity, 2),
+                       "frontal": front, "half": half, "profile": prof,
+                       "greyscale": night, "self_test": rate,
+                       "cameras": [{"camera": c, "n": k}
+                                   for c, k in sorted(known.items(), key=lambda x: -x[1])],
+                       "unknown_camera": cams.get("?", 0)})
+
+        missing = []
+        if n < 5:
+            missing.append("too few photos")
+        if not front:
+            missing.append("no frontal shot")
+        if ir_cams and not night and (known.keys() & ir_cams):
+            missing.append("no IR night shot")
+        if len(known) == 1 and n >= 3:
+            missing.append(f"only one camera ({next(iter(known))})")
+        if diversity is not None and diversity > 0.55:
+            missing.append(f"photos look very alike ({diversity:.2f})")
+        if n >= 8 and rate < 40:
+            missing.append(f"photos barely support each other (self test {rate}%)")
+        if missing:
+            advice.append({"name": g["name"], "self_test": rate, "missing": missing})
+
+    people.sort(key=lambda p: p["name"].lower())
+    advice.sort(key=lambda a: a["self_test"])
+    return {"threshold": thr, "top_k": top_k, "people": people, "advice": advice,
+            "ir_cameras": sorted(ir_cams)}
+
+
+NO_DETECTION, TOO_SMALL, UNCERTAIN, OK = "no face", "too small", "uncertain", "ok"
+
+
+def why_no_face(engine, frigate, cfg, days: float = 3.0, progress=None) -> dict:
+    """Warum liefern so viele Ereignisse kein brauchbares Gesicht?
+
+    Trennt die drei Gründe, die sich sonst zu einem „wird nicht erkannt" vermischen:
+    gar kein Gesicht im Bild, eines das zu klein ist, oder eines das die Erkennung
+    selbst nicht sicher genug findet. Erst die Aufschlüsselung nach Kamera zeigt, ob
+    ein Standort etwas taugt — oder nur Rücken und Hinterköpfe liefert.
+    """
+    from .engine import FaceEngine
+
+    if frigate is None:
+        return {"error": "no Frigate connection configured"}
+    min_px = int(cfg["faceid"].get("min_face_px", 48))
+    min_det = 0.65
+
+    after = time.time() - days * 86400
+    events, before = [], None
+    while True:
+        params = {"label": "person", "has_snapshot": 1, "limit": 100, "after": after}
+        if before:
+            params["before"] = before
+        batch = frigate.events(**params)
+        if not batch:
+            break
+        events.extend(batch)
+        before = batch[-1]["start_time"]
+        if len(batch) < 100:
+            break
+
+    reasons, per_cam, widths = Counter(), {}, []
+    for i, ev in enumerate(events):
+        if progress:
+            progress(i + 1, len(events))
+        img = frigate.snapshot(ev["id"], crop=True)
+        if img is None:
+            reasons["no snapshot"] += 1
+            continue
+        faces = engine.faces(img)
+        if not len(faces):
+            reason, w, det = NO_DETECTION, 0.0, 0.0
+        else:
+            ws = [float(f.bbox[2] - f.bbox[0]) for f in faces]
+            hs = [float(f.bbox[3] - f.bbox[1]) for f in faces]
+            big = [f for f, w, h in zip(faces, ws, hs) if w >= min_px and h >= min_px]
+            if not big:
+                reason, w, det = TOO_SMALL, max(ws), max(float(f.det_score) for f in faces)
+            else:
+                det = max(float(f.det_score) for f in big)
+                w = max(ws)
+                reason = UNCERTAIN if det < min_det else OK
+        reasons[reason] += 1
+        if w:
+            widths.append(w)
+        cam = ev.get("camera") or "?"
+        per_cam.setdefault(cam, Counter())[reason] += 1
+
+    cams = [{"camera": c, "events": sum(r.values()), "ok": r[OK],
+             "no_face": r[NO_DETECTION], "too_small": r[TOO_SMALL],
+             "uncertain": r[UNCERTAIN]}
+            for c, r in sorted(per_cam.items(), key=lambda kv: -sum(kv[1].values()))]
+    return {"days": days, "events": len(events), "min_face_px": min_px,
+            "reasons": dict(reasons), "cameras": cams,
+            "face_width": _stats(widths) if widths else {"n": 0}}

--- a/faceid-addon/app/tools.py
+++ b/faceid-addon/app/tools.py
@@ -279,8 +279,6 @@ def why_no_face(engine, frigate, cfg, days: float = 3.0, progress=None) -> dict:
     selbst nicht sicher genug findet. Erst die Aufschlüsselung nach Kamera zeigt, ob
     ein Standort etwas taugt — oder nur Rücken und Hinterköpfe liefert.
     """
-    from .engine import FaceEngine
-
     if frigate is None:
         return {"error": "no Frigate connection configured"}
     min_px = int(cfg["faceid"].get("min_face_px", 48))

--- a/faceid-addon/app/webui.py
+++ b/faceid-addon/app/webui.py
@@ -549,6 +549,77 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
     def analysis_status():
         return dict(analysis_state)
 
+    # ---- Werkzeuge -------------------------------------------------------------
+    # Dieselben Auswertungen wie in scripts/, nur ohne Shell. Noetig, weil scripts/
+    # gar nicht im App-Image liegt (das Dockerfile kopiert app/ und static/) und die
+    # Verzoegerungsmessung dort journalctl braeuchte, das es im Container nicht gibt.
+    TOOL_SPECS = [
+        {"id": "delay", "label": "How fast is a recognition?",
+         "about": "Time from the start of the event to the published name, split by "
+                  "attempt — attempt 1 is really Frigate's time to a usable snapshot. "
+                  "Reads the history, so it needs no camera access and is instant.",
+         "days": [0, 1, 3, 7, 14], "days_label": "period", "needs": "history"},
+        {"id": "coverage", "label": "How well is each person covered?",
+         "about": "Angles, cameras, day and night per person — and what photo is "
+                  "concretely missing. Re-reads every reference photo, so it takes a "
+                  "while on a large gallery.",
+         "days": [], "needs": "gallery"},
+        {"id": "why-no-face", "label": "Why do events yield no face?",
+         "about": "Separates the three reasons that otherwise blur into 'not "
+                  "recognised': no face in the picture at all, one too small, or one "
+                  "the detector is unsure about. Downloads a snapshot per event.",
+         "days": [1, 3, 7], "days_label": "look back", "needs": "frigate"},
+    ]
+    tool_state = {t["id"]: {"running": False, "processed": 0, "total": 0,
+                            "result": None} for t in TOOL_SPECS}
+
+    class ToolBody(BaseModel):
+        days: float = 3.0
+
+    @app.get("/api/tools")
+    def tools_list():
+        return {"tools": TOOL_SPECS, "state": tool_state}
+
+    @app.post("/api/tools/{tid}")
+    def start_tool(tid: str, body: ToolBody):
+        st = tool_state.get(tid)
+        if st is None:
+            raise HTTPException(404, "unknown tool")
+        if st["running"]:
+            raise HTTPException(409, "already running")
+        days = max(0.0, min(float(body.days), 30.0))
+        st.update(running=True, processed=0, total=0, result=None)
+
+        def worker():
+            from . import tools as t
+            prog = lambda i, n: st.update(processed=i, total=n)
+            try:
+                if tid == "delay":
+                    h = getattr(processor, "history", None)
+                    st["result"] = ({"error": "history is disabled (history_keep: 0)"}
+                                    if h is None else t.delay(h.dir, days=days))
+                elif tid == "coverage":
+                    st["result"] = t.coverage(data_dir, engine, processor.frigate, cfg,
+                                              progress=prog)
+                else:
+                    st["result"] = t.why_no_face(engine, processor.frigate, cfg,
+                                                 days=days, progress=prog)
+            except Exception as e:
+                log.exception("tool %s failed", tid)
+                st["result"] = {"error": str(e)}
+            finally:
+                st["running"] = False
+
+        threading.Thread(target=worker, daemon=True, name=f"faceid-tool-{tid}").start()
+        return {"started": True, "days": days}
+
+    @app.get("/api/tools/{tid}")
+    def tool_status(tid: str):
+        st = tool_state.get(tid)
+        if st is None:
+            raise HTTPException(404, "unknown tool")
+        return dict(st)
+
     @app.get("/api/backups")
     def backups():
         """Gespeicherte Backups auflisten — wer FaceID als App betreibt, kommt sonst gar

--- a/faceid-addon/app/webui.py
+++ b/faceid-addon/app/webui.py
@@ -371,8 +371,8 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
             backfill_state.update(processed=i, total=total)
 
         def worker():
-            from .backfill import run_backfill
             try:
+                from .backfill import run_backfill
                 stats = run_backfill(
                     engine, gallery, processor.frigate, cfg["frigate"]["url"], days=days,
                     tag=bool(cfg["faceid"].get("set_sub_label", True)),
@@ -540,8 +540,8 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
             analysis_state.update(running=True, processed=0, total=0, result=None)
 
         def worker():
-            from . import analysis
             try:
+                from . import analysis
                 analysis_state["result"] = analysis.run(
                     data_dir, engine, processor.frigate, cfg, days=days,
                     progress=lambda i, t: analysis_state.update(processed=i, total=t))
@@ -601,9 +601,12 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
             st.update(running=True, processed=0, total=0, result=None)
 
         def worker():
-            from . import tools as t
-            prog = lambda i, n: st.update(processed=i, total=n)
+            # Der Import gehoert INS try: schlaegt er fehl, stirbt der Thread sonst vor
+            # dem finally, "running" bliebe fuer immer True und das Werkzeug waere bis
+            # zum Neustart tot — mit "already running" als einziger Auskunft.
             try:
+                from . import tools as t
+                prog = lambda i, n: st.update(processed=i, total=n)
                 if tid == "delay":
                     h = getattr(processor, "history", None)
                     st["result"] = ({"error": "history is disabled (history_keep: 0)"}

--- a/faceid-addon/app/webui.py
+++ b/faceid-addon/app/webui.py
@@ -347,6 +347,13 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
             gallery.discard_unknown(uid)
         return {"ok": True}
 
+    # Pruefen und Setzen von "running" muss zusammen passieren. FastAPI fuehrt
+    # synchrone Endpunkte in einem Threadpool aus, und zwischen der Abfrage und dem
+    # Setzen liegt eine Zuweisung — dort kann Python den Thread wechseln. Zwei
+    # gleichzeitige Starts kaemen sonst beide durch die 409-Sperre und wuerden in
+    # denselben Zustand schreiben. Die Sperre haelt nur den Check-and-Set, nie den Lauf.
+    job_lock = threading.Lock()
+
     backfill_state = {"running": False, "processed": 0, "total": 0, "result": None, "days": 0}
 
     class BackfillBody(BaseModel):
@@ -354,10 +361,11 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
 
     @app.post("/api/backfill")
     def start_backfill(body: BackfillBody):
-        if backfill_state["running"]:
-            raise HTTPException(409, "History scan already running")
         days = max(1, min(int(body.days), 60))
-        backfill_state.update(running=True, processed=0, total=0, result=None, days=days)
+        with job_lock:
+            if backfill_state["running"]:
+                raise HTTPException(409, "History scan already running")
+            backfill_state.update(running=True, processed=0, total=0, result=None, days=days)
 
         def progress(i, total):
             backfill_state.update(processed=i, total=total)
@@ -525,10 +533,11 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
     def start_analysis(body: AnalysisBody):
         """Kalibrierungs-Auswertung anstossen — dieselbe Rechnung wie die Skripte,
         aber ohne Shell, damit App-Nutzer sie ueberhaupt ausfuehren koennen."""
-        if analysis_state["running"]:
-            raise HTTPException(409, "analysis already running")
         days = max(0.0, min(float(body.days), 30.0))
-        analysis_state.update(running=True, processed=0, total=0, result=None)
+        with job_lock:
+            if analysis_state["running"]:
+                raise HTTPException(409, "analysis already running")
+            analysis_state.update(running=True, processed=0, total=0, result=None)
 
         def worker():
             from . import analysis
@@ -585,10 +594,11 @@ def build_app(cfg, engine, gallery, processor, data_dir: Path, static_dir: Path)
         st = tool_state.get(tid)
         if st is None:
             raise HTTPException(404, "unknown tool")
-        if st["running"]:
-            raise HTTPException(409, "already running")
         days = max(0.0, min(float(body.days), 30.0))
-        st.update(running=True, processed=0, total=0, result=None)
+        with job_lock:
+            if st["running"]:
+                raise HTTPException(409, "already running")
+            st.update(running=True, processed=0, total=0, result=None)
 
         def worker():
             from . import tools as t

--- a/faceid-addon/config.yaml
+++ b/faceid-addon/config.yaml
@@ -1,5 +1,5 @@
 name: FaceID
-version: "0.21.0"
+version: "0.22.0"
 slug: faceid
 description: Face recognition for Frigate — trainable gallery, clustered unknown review, HA sensors
 url: https://github.com/SkyTechNerds/faceid

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -16,6 +16,12 @@ body{background:var(--bg);color:var(--fg);font:14px/1.45 var(--sans)}
 header{display:flex;align-items:baseline;gap:16px;padding:10px 16px;border-bottom:1px solid var(--line)}
 header h1{font:700 15px var(--mono);color:var(--acc);letter-spacing:.08em}
 header .stat{font:12px var(--mono);color:var(--dim)}
+table.t{border-collapse:collapse;font-size:12px;margin:2px 0 14px}
+table.t th{text-align:right;color:var(--dim);font-weight:400;padding:3px 10px 3px 0;
+  border-bottom:1px solid var(--line)}
+table.t th:first-child,table.t td:first-child{text-align:left}
+table.t td{text-align:right;padding:3px 10px 3px 0;border-bottom:1px solid var(--line)}
+table.t tr:last-child td{border-bottom:0}
 nav{display:flex;gap:0;border-bottom:1px solid var(--line)}
 nav button{background:none;border:0;border-right:1px solid var(--line);color:var(--dim);
   font:13px var(--mono);padding:8px 18px;cursor:pointer}
@@ -132,6 +138,7 @@ td.p{color:var(--acc)} td.u{color:var(--warn)}
   <button data-t="settings" title="matching thresholds, backup and restore">SETTINGS</button>
   <button data-t="history" title="what FaceID actually reported — with the face image it used, and a way to say it was wrong">HISTORY</button>
   <button data-t="log" title="recent service log — what FaceID is doing, and why nothing was recognised">LOG</button>
+  <button data-t="tools" title="deeper measurements: speed, gallery coverage, why events yield no face" hidden>TOOLS</button>
 </nav>
 <main id="main"></main>
 <div id="toast"></div>
@@ -182,6 +189,7 @@ async function render(){
   if(tab==='settings')return renderSettings();
   if(tab==='history')return renderHistory();
   if(tab==='log')return renderLog();
+  if(tab==='tools')return renderTools();
   return renderPersons();
 }
 
@@ -750,6 +758,14 @@ async function renderSettings(){
       <span class="stat">tests the gallery against itself (real ground truth) and against recent events. Runs in the background; a few minutes.</span>
     </div>
     <div id="anbox" style="margin-bottom:18px"></div>
+    <div class="row" style="margin-bottom:18px">
+      <label style="display:flex;gap:8px;align-items:center"><input type="checkbox" id="advOn"
+        onchange="setAdvanced(this.checked)"> show the Tools tab</label>
+      <span class="stat" style="max-width:70ch">Adds a tab with deeper measurements:
+        how fast recognition is, how well each person is covered, and why events yield
+        no face. Same analyses as the scripts in the repository, without a terminal.
+        This setting lives in this browser only.</span>
+    </div>
 
     <h2>Automatic backup</h2>
     <div class="row">
@@ -776,6 +792,7 @@ async function renderSettings(){
   dedupePreview();
   renderBackupList();
   renderAnalysis();
+  const adv=document.getElementById('advOn'); if(adv)adv.checked=advanced();
 }
 
 // Die Einstellungen sind ueber die Zeit auf acht Abschnitte gewachsen — als eine lange
@@ -1015,6 +1032,144 @@ async function ignorePerson(slug,name){
 async function delPerson(slug,name){if(!confirm(`Delete "${name}" and all their faces?`))return;
   await j(`api/persons/${slug}`,{method:'DELETE'});render()}
 
+
+// ---- TOOLS -----------------------------------------------------------------
+// Die Auswertungen laufen im Dienst, nicht im Browser: sie brauchen die Galerie,
+// die Erkennung und teils Frigate. Hier steht nur die Darstellung.
+const ADV='faceid.advanced';
+function advanced(){return localStorage.getItem(ADV)==='1'}
+function applyAdvanced(){
+  const b=document.querySelector('nav button[data-t="tools"]');
+  if(b)b.hidden=!advanced();
+  // Wer den Modus abschaltet, waehrend er im Tab steht, saesse sonst auf einer
+  // Seite, die es laut Navigation nicht mehr gibt.
+  if(!advanced()&&tab==='tools')document.querySelector('nav button[data-t="unknowns"]').click();
+}
+function setAdvanced(on){
+  localStorage.setItem(ADV,on?'1':'0');applyAdvanced();
+  toast(on?'Tools tab enabled':'Tools tab hidden');
+}
+
+function tbl(cols,rows){
+  if(!rows.length)return '';
+  return `<table class="t"><tr>${cols.map(c=>`<th>${esc(c[0])}</th>`).join('')}</tr>`+
+    rows.map(r=>`<tr>${cols.map(c=>`<td>${c[1](r)??'—'}</td>`).join('')}</tr>`).join('')+
+    '</table>';
+}
+const secs=v=>v==null?'—':`${v.toFixed?v.toFixed(1):v}s`;
+
+function fmtDelay(d){
+  if(d.error)return `<span class="stat">${esc(d.error)}</span>`;
+  if(!d.n)return `<span class="stat">${esc(d.note||'nothing recorded yet')}</span>`;
+  let h=`<p class="stat" style="max-width:105ch"><b>${d.n}</b> recognitions ·
+    median <b>${secs(d.median)}</b> · fastest ${secs(d.min)} · 9 of 10 within
+    ${secs(d.p90)}${d.skipped_late?` · ${d.skipped_late} ignored as history-scan results`:''}</p>`;
+  h+=tbl([['attempt',r=>r.attempt],['n',r=>r.n],['median',r=>secs(r.median)],
+          ['fastest',r=>secs(r.min)],['slowest',r=>secs(r.max)]],d.by_attempt||[]);
+  h+=`<p class="stat">Attempt 1 is not FaceID's speed — it is how long Frigate takes to
+     produce a usable snapshot. That is the floor everything else sits on.</p>`;
+  h+=tbl([['camera',r=>esc(r.camera)],['n',r=>r.n],['median',r=>secs(r.median)]],d.by_camera||[]);
+  if((d.by_day||[]).length>1)
+    h+=tbl([['day',r=>esc(r.day)],['n',r=>r.n],['median',r=>secs(r.median)]],d.by_day);
+  return h;
+}
+
+function fmtCoverage(d){
+  if(d.error)return `<span class="stat">${esc(d.error)}</span>`;
+  let h='';
+  if((d.ir_cameras||[]).length)
+    h+=`<p class="stat">cameras that switch to infrared at night:
+        ${d.ir_cameras.map(esc).join(', ')}</p>`;
+  h+=tbl([['person',r=>esc(r.name)],['photos',r=>r.photos],
+          ['alike',r=>r.diversity==null?'—':r.diversity.toFixed(2)],
+          ['frontal',r=>r.frontal],['half',r=>r.half],['profile',r=>r.profile],
+          ['grey',r=>r.greyscale],['self test',r=>r.self_test+'%'],
+          ['cameras',r=>r.cameras.map(c=>esc(c.camera)+' '+c.n).join(', ')||'—']],
+         d.people||[]);
+  h+=`<p class="stat" style="max-width:105ch">The self test is deliberately harsh and
+     pessimistic on small galleries — one photo has to hold up against all the others.
+     A low value means the photos support each other weakly, not that the person will
+     not be recognised.</p>`;
+  if((d.advice||[]).length)
+    h+='<p class="stat">What is concretely missing (weakest first):</p><ul class="stat">'+
+       d.advice.map(a=>`<li><b>${esc(a.name)}</b>: ${a.missing.map(esc).join(', ')}</li>`).join('')+
+       '</ul>';
+  else h+='<p class="stat">Every person is broadly covered.</p>';
+  return h;
+}
+
+function fmtWhy(d){
+  if(d.error)return `<span class="stat">${esc(d.error)}</span>`;
+  const r=d.reasons||{}, tot=d.events||0;
+  const pct=n=>tot?` (${Math.round(100*n/tot)}%)`:'';
+  let h=`<p class="stat" style="max-width:105ch"><b>${tot}</b> events ·
+    usable face <b>${r.ok||0}</b>${pct(r.ok||0)} · no face at all ${r['no face']||0}
+    · too small ${r['too small']||0} · detector unsure ${r.uncertain||0}
+    ${r['no snapshot']?`· no snapshot ${r['no snapshot']}`:''}</p>`;
+  if(d.face_width&&d.face_width.n)
+    h+=`<p class="stat">widest face per event: median ${d.face_width.median}px,
+        threshold is ${d.min_face_px}px</p>`;
+  h+=tbl([['camera',r=>esc(r.camera)],['events',r=>r.events],['ok',r=>r.ok],
+          ['no face',r=>r.no_face],['too small',r=>r.too_small],
+          ['unsure',r=>r.uncertain]],d.cameras||[]);
+  return h;
+}
+const TOOL_FMT={'delay':fmtDelay,'coverage':fmtCoverage,'why-no-face':fmtWhy};
+
+function toolCard(t,st){
+  const days=(t.days||[]).length?`<label class="stat" style="display:flex;gap:6px;align-items:center">
+      ${esc(t.days_label||'period')}
+      <select id="td-${t.id}">${t.days.map(d=>`<option value="${d}"${d===(t.days[1]??t.days[0])?' selected':''}>${d?d+' day'+(d>1?'s':''):'everything'}</option>`).join('')}</select>
+    </label>`:'';
+  return `<h2>${esc(t.label)}</h2>
+    <div class="row">
+      <button class="act" onclick="runTool('${t.id}')" ${st&&st.running?'disabled':''}>RUN</button>
+      ${days}
+      <span class="stat" style="max-width:70ch">${esc(t.about)}</span>
+    </div>
+    <div id="tb-${t.id}" style="margin-bottom:18px"></div>`;
+}
+
+async function renderTools(){
+  main.innerHTML='<span class="stat">loading…</span>';
+  let d; try{ d=await j('api/tools') }catch(e){ main.innerHTML='<span class="stat">tools unavailable</span>'; return }
+  if(tab!=='tools')return;
+  main.innerHTML=`<p class="stat" style="max-width:105ch">Measurements that used to live
+    in <code>scripts/</code> and needed a terminal. They read what FaceID already has —
+    nothing here changes your gallery.</p>`+
+    d.tools.map(t=>toolCard(t,d.state[t.id])).join('');
+  for(const t of d.tools)paintTool(t.id,d.state[t.id]);
+}
+
+function paintTool(id,st){
+  const el=document.getElementById('tb-'+id); if(!el||!st)return;
+  if(st.running){
+    const pct=st.total?Math.round(100*st.processed/st.total):0;
+    el.innerHTML=`<span class="stat">measuring… ${st.processed}/${st.total||'?'}${st.total?` (${pct}%)`:''}</span>`;
+    setTimeout(()=>pollTool(id),1000);
+  } else if(st.result){
+    el.innerHTML=(TOOL_FMT[id]||(r=>`<pre class="stat">${esc(JSON.stringify(r,null,2))}</pre>`))(st.result);
+    const b=el.parentElement&&document.querySelector(`button[onclick="runTool('${id}')"]`);
+    if(b)b.disabled=false;
+  }
+}
+
+async function pollTool(id){
+  if(tab!=='tools')return;
+  try{ paintTool(id,await j('api/tools/'+id)) }catch(e){}
+}
+
+async function runTool(id){
+  const sel=document.getElementById('td-'+id);
+  try{ await j('api/tools/'+id,{method:'POST',headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({days:+(sel?sel.value:0)})}) }
+  catch(e){ return toast('already running') }
+  const b=document.querySelector(`button[onclick="runTool('${id}')"]`); if(b)b.disabled=true;
+  const el=document.getElementById('tb-'+id); if(el)el.innerHTML='<span class="stat">starting…</span>';
+  pollTool(id);
+}
+
+applyAdvanced();
 
 health();setInterval(health,10000);render();
 </script>

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -758,14 +758,15 @@ async function renderSettings(){
       <span class="stat">tests the gallery against itself (real ground truth) and against recent events. Runs in the background; a few minutes.</span>
     </div>
     <div id="anbox" style="margin-bottom:18px"></div>
-    <div class="row" style="margin-bottom:18px">
+    <div class="row">
       <label style="display:flex;gap:8px;align-items:center"><input type="checkbox" id="advOn"
         onchange="setAdvanced(this.checked)"> show the Tools tab</label>
-      <span class="stat" style="max-width:70ch">Adds a tab with deeper measurements:
-        how fast recognition is, how well each person is covered, and why events yield
-        no face. Same analyses as the scripts in the repository, without a terminal.
-        This setting lives in this browser only.</span>
     </div>
+    <div class="stat" style="max-width:105ch;margin-bottom:18px">Adds a tab with deeper
+      measurements: how fast recognition is, how well each person is covered, and why events
+      yield no usable face. The same analyses as the scripts in the repository, but without a
+      terminal — which is the point, since the scripts are not part of the app image at all.
+      This switch lives in this browser only.</div>
 
     <h2>Automatic backup</h2>
     <div class="row">

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -16,7 +16,7 @@ body{background:var(--bg);color:var(--fg);font:14px/1.45 var(--sans)}
 header{display:flex;align-items:baseline;gap:16px;padding:10px 16px;border-bottom:1px solid var(--line)}
 header h1{font:700 15px var(--mono);color:var(--acc);letter-spacing:.08em}
 header .stat{font:12px var(--mono);color:var(--dim)}
-table.t{border-collapse:collapse;font-size:12px;margin:2px 0 14px}
+table.t{border-collapse:collapse;width:auto;max-width:100%;font-size:12px;margin:2px 0 14px}
 table.t th{text-align:right;color:var(--dim);font-weight:400;padding:3px 10px 3px 0;
   border-bottom:1px solid var(--line)}
 table.t th:first-child,table.t td:first-child{text-align:left}

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -1109,9 +1109,13 @@ function fmtWhy(d){
   if(d.face_width&&d.face_width.n)
     h+=`<p class="stat">widest face per event: median ${d.face_width.median}px,
         threshold is ${d.min_face_px}px</p>`;
-  h+=tbl([['camera',r=>esc(r.camera)],['events',r=>r.events],['ok',r=>r.ok],
+  h+=tbl([['camera',r=>esc(r.camera)+(r.used?'':' <span class="stat">(not processed)</span>')],
+          ['events',r=>r.events],['ok',r=>r.ok],
           ['no face',r=>r.no_face],['too small',r=>r.too_small],
           ['unsure',r=>r.uncertain]],d.cameras||[]);
+  h+=`<p class="stat" style="max-width:105ch">Cameras FaceID does not process are measured
+     too — that is the point: it shows whether adding one would be worth it, or whether an
+     existing one only ever delivers backs of heads.</p>`;
   return h;
 }
 const TOOL_FMT={'delay':fmtDelay,'coverage':fmtCoverage,'why-no-face':fmtWhy};

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -513,7 +513,9 @@ async function renderHistory(){
         <div class="meta">
           <b title="${esc(h.person)} ${h.score}">${esc(h.person)} ${h.score}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>
-          ${h.now?`<div class="nowis" title="This face would be matched to ${esc(h.now.person)} today — the gallery has changed since this was reported.">now: ${esc(h.now.person)} ${h.now.score}</div>`:''}
+          ${h.now?(h.now.self
+            ? `<div class="nowis" title="You assigned this face to ${esc(h.now.person)}, so it is one of their reference photos now. It matches itself — that says nothing about how well ${esc(h.now.person)} is recognised.">now assigned: ${esc(h.now.person)}</div>`
+            : `<div class="nowis" title="This face would be matched to ${esc(h.now.person)} today — the gallery has changed since this was reported.">now: ${esc(h.now.person)} ${h.now.score}</div>`):''}
         </div>
         <button class="ghost" onclick="markWrong('${h.id}')">was wrong</button>
       </div>`).join('')}</div>

--- a/static/index.html
+++ b/static/index.html
@@ -16,6 +16,12 @@ body{background:var(--bg);color:var(--fg);font:14px/1.45 var(--sans)}
 header{display:flex;align-items:baseline;gap:16px;padding:10px 16px;border-bottom:1px solid var(--line)}
 header h1{font:700 15px var(--mono);color:var(--acc);letter-spacing:.08em}
 header .stat{font:12px var(--mono);color:var(--dim)}
+table.t{border-collapse:collapse;font-size:12px;margin:2px 0 14px}
+table.t th{text-align:right;color:var(--dim);font-weight:400;padding:3px 10px 3px 0;
+  border-bottom:1px solid var(--line)}
+table.t th:first-child,table.t td:first-child{text-align:left}
+table.t td{text-align:right;padding:3px 10px 3px 0;border-bottom:1px solid var(--line)}
+table.t tr:last-child td{border-bottom:0}
 nav{display:flex;gap:0;border-bottom:1px solid var(--line)}
 nav button{background:none;border:0;border-right:1px solid var(--line);color:var(--dim);
   font:13px var(--mono);padding:8px 18px;cursor:pointer}
@@ -132,6 +138,7 @@ td.p{color:var(--acc)} td.u{color:var(--warn)}
   <button data-t="settings" title="matching thresholds, backup and restore">SETTINGS</button>
   <button data-t="history" title="what FaceID actually reported — with the face image it used, and a way to say it was wrong">HISTORY</button>
   <button data-t="log" title="recent service log — what FaceID is doing, and why nothing was recognised">LOG</button>
+  <button data-t="tools" title="deeper measurements: speed, gallery coverage, why events yield no face" hidden>TOOLS</button>
 </nav>
 <main id="main"></main>
 <div id="toast"></div>
@@ -182,6 +189,7 @@ async function render(){
   if(tab==='settings')return renderSettings();
   if(tab==='history')return renderHistory();
   if(tab==='log')return renderLog();
+  if(tab==='tools')return renderTools();
   return renderPersons();
 }
 
@@ -750,6 +758,14 @@ async function renderSettings(){
       <span class="stat">tests the gallery against itself (real ground truth) and against recent events. Runs in the background; a few minutes.</span>
     </div>
     <div id="anbox" style="margin-bottom:18px"></div>
+    <div class="row" style="margin-bottom:18px">
+      <label style="display:flex;gap:8px;align-items:center"><input type="checkbox" id="advOn"
+        onchange="setAdvanced(this.checked)"> show the Tools tab</label>
+      <span class="stat" style="max-width:70ch">Adds a tab with deeper measurements:
+        how fast recognition is, how well each person is covered, and why events yield
+        no face. Same analyses as the scripts in the repository, without a terminal.
+        This setting lives in this browser only.</span>
+    </div>
 
     <h2>Automatic backup</h2>
     <div class="row">
@@ -776,6 +792,7 @@ async function renderSettings(){
   dedupePreview();
   renderBackupList();
   renderAnalysis();
+  const adv=document.getElementById('advOn'); if(adv)adv.checked=advanced();
 }
 
 // Die Einstellungen sind ueber die Zeit auf acht Abschnitte gewachsen — als eine lange
@@ -1015,6 +1032,144 @@ async function ignorePerson(slug,name){
 async function delPerson(slug,name){if(!confirm(`Delete "${name}" and all their faces?`))return;
   await j(`api/persons/${slug}`,{method:'DELETE'});render()}
 
+
+// ---- TOOLS -----------------------------------------------------------------
+// Die Auswertungen laufen im Dienst, nicht im Browser: sie brauchen die Galerie,
+// die Erkennung und teils Frigate. Hier steht nur die Darstellung.
+const ADV='faceid.advanced';
+function advanced(){return localStorage.getItem(ADV)==='1'}
+function applyAdvanced(){
+  const b=document.querySelector('nav button[data-t="tools"]');
+  if(b)b.hidden=!advanced();
+  // Wer den Modus abschaltet, waehrend er im Tab steht, saesse sonst auf einer
+  // Seite, die es laut Navigation nicht mehr gibt.
+  if(!advanced()&&tab==='tools')document.querySelector('nav button[data-t="unknowns"]').click();
+}
+function setAdvanced(on){
+  localStorage.setItem(ADV,on?'1':'0');applyAdvanced();
+  toast(on?'Tools tab enabled':'Tools tab hidden');
+}
+
+function tbl(cols,rows){
+  if(!rows.length)return '';
+  return `<table class="t"><tr>${cols.map(c=>`<th>${esc(c[0])}</th>`).join('')}</tr>`+
+    rows.map(r=>`<tr>${cols.map(c=>`<td>${c[1](r)??'—'}</td>`).join('')}</tr>`).join('')+
+    '</table>';
+}
+const secs=v=>v==null?'—':`${v.toFixed?v.toFixed(1):v}s`;
+
+function fmtDelay(d){
+  if(d.error)return `<span class="stat">${esc(d.error)}</span>`;
+  if(!d.n)return `<span class="stat">${esc(d.note||'nothing recorded yet')}</span>`;
+  let h=`<p class="stat" style="max-width:105ch"><b>${d.n}</b> recognitions ·
+    median <b>${secs(d.median)}</b> · fastest ${secs(d.min)} · 9 of 10 within
+    ${secs(d.p90)}${d.skipped_late?` · ${d.skipped_late} ignored as history-scan results`:''}</p>`;
+  h+=tbl([['attempt',r=>r.attempt],['n',r=>r.n],['median',r=>secs(r.median)],
+          ['fastest',r=>secs(r.min)],['slowest',r=>secs(r.max)]],d.by_attempt||[]);
+  h+=`<p class="stat">Attempt 1 is not FaceID's speed — it is how long Frigate takes to
+     produce a usable snapshot. That is the floor everything else sits on.</p>`;
+  h+=tbl([['camera',r=>esc(r.camera)],['n',r=>r.n],['median',r=>secs(r.median)]],d.by_camera||[]);
+  if((d.by_day||[]).length>1)
+    h+=tbl([['day',r=>esc(r.day)],['n',r=>r.n],['median',r=>secs(r.median)]],d.by_day);
+  return h;
+}
+
+function fmtCoverage(d){
+  if(d.error)return `<span class="stat">${esc(d.error)}</span>`;
+  let h='';
+  if((d.ir_cameras||[]).length)
+    h+=`<p class="stat">cameras that switch to infrared at night:
+        ${d.ir_cameras.map(esc).join(', ')}</p>`;
+  h+=tbl([['person',r=>esc(r.name)],['photos',r=>r.photos],
+          ['alike',r=>r.diversity==null?'—':r.diversity.toFixed(2)],
+          ['frontal',r=>r.frontal],['half',r=>r.half],['profile',r=>r.profile],
+          ['grey',r=>r.greyscale],['self test',r=>r.self_test+'%'],
+          ['cameras',r=>r.cameras.map(c=>esc(c.camera)+' '+c.n).join(', ')||'—']],
+         d.people||[]);
+  h+=`<p class="stat" style="max-width:105ch">The self test is deliberately harsh and
+     pessimistic on small galleries — one photo has to hold up against all the others.
+     A low value means the photos support each other weakly, not that the person will
+     not be recognised.</p>`;
+  if((d.advice||[]).length)
+    h+='<p class="stat">What is concretely missing (weakest first):</p><ul class="stat">'+
+       d.advice.map(a=>`<li><b>${esc(a.name)}</b>: ${a.missing.map(esc).join(', ')}</li>`).join('')+
+       '</ul>';
+  else h+='<p class="stat">Every person is broadly covered.</p>';
+  return h;
+}
+
+function fmtWhy(d){
+  if(d.error)return `<span class="stat">${esc(d.error)}</span>`;
+  const r=d.reasons||{}, tot=d.events||0;
+  const pct=n=>tot?` (${Math.round(100*n/tot)}%)`:'';
+  let h=`<p class="stat" style="max-width:105ch"><b>${tot}</b> events ·
+    usable face <b>${r.ok||0}</b>${pct(r.ok||0)} · no face at all ${r['no face']||0}
+    · too small ${r['too small']||0} · detector unsure ${r.uncertain||0}
+    ${r['no snapshot']?`· no snapshot ${r['no snapshot']}`:''}</p>`;
+  if(d.face_width&&d.face_width.n)
+    h+=`<p class="stat">widest face per event: median ${d.face_width.median}px,
+        threshold is ${d.min_face_px}px</p>`;
+  h+=tbl([['camera',r=>esc(r.camera)],['events',r=>r.events],['ok',r=>r.ok],
+          ['no face',r=>r.no_face],['too small',r=>r.too_small],
+          ['unsure',r=>r.uncertain]],d.cameras||[]);
+  return h;
+}
+const TOOL_FMT={'delay':fmtDelay,'coverage':fmtCoverage,'why-no-face':fmtWhy};
+
+function toolCard(t,st){
+  const days=(t.days||[]).length?`<label class="stat" style="display:flex;gap:6px;align-items:center">
+      ${esc(t.days_label||'period')}
+      <select id="td-${t.id}">${t.days.map(d=>`<option value="${d}"${d===(t.days[1]??t.days[0])?' selected':''}>${d?d+' day'+(d>1?'s':''):'everything'}</option>`).join('')}</select>
+    </label>`:'';
+  return `<h2>${esc(t.label)}</h2>
+    <div class="row">
+      <button class="act" onclick="runTool('${t.id}')" ${st&&st.running?'disabled':''}>RUN</button>
+      ${days}
+      <span class="stat" style="max-width:70ch">${esc(t.about)}</span>
+    </div>
+    <div id="tb-${t.id}" style="margin-bottom:18px"></div>`;
+}
+
+async function renderTools(){
+  main.innerHTML='<span class="stat">loading…</span>';
+  let d; try{ d=await j('api/tools') }catch(e){ main.innerHTML='<span class="stat">tools unavailable</span>'; return }
+  if(tab!=='tools')return;
+  main.innerHTML=`<p class="stat" style="max-width:105ch">Measurements that used to live
+    in <code>scripts/</code> and needed a terminal. They read what FaceID already has —
+    nothing here changes your gallery.</p>`+
+    d.tools.map(t=>toolCard(t,d.state[t.id])).join('');
+  for(const t of d.tools)paintTool(t.id,d.state[t.id]);
+}
+
+function paintTool(id,st){
+  const el=document.getElementById('tb-'+id); if(!el||!st)return;
+  if(st.running){
+    const pct=st.total?Math.round(100*st.processed/st.total):0;
+    el.innerHTML=`<span class="stat">measuring… ${st.processed}/${st.total||'?'}${st.total?` (${pct}%)`:''}</span>`;
+    setTimeout(()=>pollTool(id),1000);
+  } else if(st.result){
+    el.innerHTML=(TOOL_FMT[id]||(r=>`<pre class="stat">${esc(JSON.stringify(r,null,2))}</pre>`))(st.result);
+    const b=el.parentElement&&document.querySelector(`button[onclick="runTool('${id}')"]`);
+    if(b)b.disabled=false;
+  }
+}
+
+async function pollTool(id){
+  if(tab!=='tools')return;
+  try{ paintTool(id,await j('api/tools/'+id)) }catch(e){}
+}
+
+async function runTool(id){
+  const sel=document.getElementById('td-'+id);
+  try{ await j('api/tools/'+id,{method:'POST',headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({days:+(sel?sel.value:0)})}) }
+  catch(e){ return toast('already running') }
+  const b=document.querySelector(`button[onclick="runTool('${id}')"]`); if(b)b.disabled=true;
+  const el=document.getElementById('tb-'+id); if(el)el.innerHTML='<span class="stat">starting…</span>';
+  pollTool(id);
+}
+
+applyAdvanced();
 
 health();setInterval(health,10000);render();
 </script>

--- a/static/index.html
+++ b/static/index.html
@@ -758,14 +758,15 @@ async function renderSettings(){
       <span class="stat">tests the gallery against itself (real ground truth) and against recent events. Runs in the background; a few minutes.</span>
     </div>
     <div id="anbox" style="margin-bottom:18px"></div>
-    <div class="row" style="margin-bottom:18px">
+    <div class="row">
       <label style="display:flex;gap:8px;align-items:center"><input type="checkbox" id="advOn"
         onchange="setAdvanced(this.checked)"> show the Tools tab</label>
-      <span class="stat" style="max-width:70ch">Adds a tab with deeper measurements:
-        how fast recognition is, how well each person is covered, and why events yield
-        no face. Same analyses as the scripts in the repository, without a terminal.
-        This setting lives in this browser only.</span>
     </div>
+    <div class="stat" style="max-width:105ch;margin-bottom:18px">Adds a tab with deeper
+      measurements: how fast recognition is, how well each person is covered, and why events
+      yield no usable face. The same analyses as the scripts in the repository, but without a
+      terminal — which is the point, since the scripts are not part of the app image at all.
+      This switch lives in this browser only.</div>
 
     <h2>Automatic backup</h2>
     <div class="row">

--- a/static/index.html
+++ b/static/index.html
@@ -16,7 +16,7 @@ body{background:var(--bg);color:var(--fg);font:14px/1.45 var(--sans)}
 header{display:flex;align-items:baseline;gap:16px;padding:10px 16px;border-bottom:1px solid var(--line)}
 header h1{font:700 15px var(--mono);color:var(--acc);letter-spacing:.08em}
 header .stat{font:12px var(--mono);color:var(--dim)}
-table.t{border-collapse:collapse;font-size:12px;margin:2px 0 14px}
+table.t{border-collapse:collapse;width:auto;max-width:100%;font-size:12px;margin:2px 0 14px}
 table.t th{text-align:right;color:var(--dim);font-weight:400;padding:3px 10px 3px 0;
   border-bottom:1px solid var(--line)}
 table.t th:first-child,table.t td:first-child{text-align:left}

--- a/static/index.html
+++ b/static/index.html
@@ -1109,9 +1109,13 @@ function fmtWhy(d){
   if(d.face_width&&d.face_width.n)
     h+=`<p class="stat">widest face per event: median ${d.face_width.median}px,
         threshold is ${d.min_face_px}px</p>`;
-  h+=tbl([['camera',r=>esc(r.camera)],['events',r=>r.events],['ok',r=>r.ok],
+  h+=tbl([['camera',r=>esc(r.camera)+(r.used?'':' <span class="stat">(not processed)</span>')],
+          ['events',r=>r.events],['ok',r=>r.ok],
           ['no face',r=>r.no_face],['too small',r=>r.too_small],
           ['unsure',r=>r.uncertain]],d.cameras||[]);
+  h+=`<p class="stat" style="max-width:105ch">Cameras FaceID does not process are measured
+     too — that is the point: it shows whether adding one would be worth it, or whether an
+     existing one only ever delivers backs of heads.</p>`;
   return h;
 }
 const TOOL_FMT={'delay':fmtDelay,'coverage':fmtCoverage,'why-no-face':fmtWhy};

--- a/static/index.html
+++ b/static/index.html
@@ -513,7 +513,9 @@ async function renderHistory(){
         <div class="meta">
           <b title="${esc(h.person)} ${h.score}">${esc(h.person)} ${h.score}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>
-          ${h.now?`<div class="nowis" title="This face would be matched to ${esc(h.now.person)} today — the gallery has changed since this was reported.">now: ${esc(h.now.person)} ${h.now.score}</div>`:''}
+          ${h.now?(h.now.self
+            ? `<div class="nowis" title="You assigned this face to ${esc(h.now.person)}, so it is one of their reference photos now. It matches itself — that says nothing about how well ${esc(h.now.person)} is recognised.">now assigned: ${esc(h.now.person)}</div>`
+            : `<div class="nowis" title="This face would be matched to ${esc(h.now.person)} today — the gallery has changed since this was reported.">now: ${esc(h.now.person)} ${h.now.score}</div>`):''}
         </div>
         <button class="ghost" onclick="markWrong('${h.id}')">was wrong</button>
       </div>`).join('')}</div>


### PR DESCRIPTION
## Why

Answers here and in the docs kept saying "measure it with `scripts/…`". For anyone running
FaceID as a Home Assistant app that is not advice — it is unreachable:

- `scripts/` is **not in the app image**. The Dockerfile copies `app/`, `static/` and `run.sh`.
- `measure-delay.py` reads **`journalctl`**, which does not exist in a container without systemd.

So a button that shells out to the scripts would not have worked. The analyses moved into
`app/tools.py`, where the code is shipped anyway — the same route `/api/analysis` took for
issue #7.

## What

A **Tools** tab, hidden unless switched on under *Settings → Does it work?*:

| Tool | Source | Cost |
|---|---|---|
| How fast is a recognition? | the history, not the log | instant |
| How well is each person covered? | gallery + engine | 211 photos ≈ 65 s |
| Why do events yield no face? | one Frigate snapshot per event | ~1 s per event |

The delay figures come from the history because both halves are already there: the event
start is in the Frigate event id, the moment the name went out is in the entry. No log, no
camera access. History-scan results are excluded rather than averaged in — they lag their
event by weeks — and the count of what was dropped is shown.

## Corrections this turned up

- **There is no 3-second floor.** README and the notification blueprint claimed the name
  takes 3 s at best, "because that is how long Frigate takes to produce the first snapshot".
  18% of recognitions land below that, the fastest in 0.8 s. The old number was the *median*
  of first attempts written up as a physical limit. Verified two ways before changing
  anything: the log-based script and the history-based tool agree (median 8–9 s, fastest ~1 s),
  and the clocks of Frigate and the container match to the second, so the fast cases are not
  a time offset.
- **The history no longer shows a similarity of 1.0 as if it meant something.** Every such
  entry was a face that had since been assigned, so it is one of that person's reference
  photos and matches itself. Now reads "now assigned: \<name\>", without a number.
- **The IR check asked Frigate for every camera** and advised an infrared shot for a camera
  that had been out of the list for days. Now limited to processed cameras. `why-no-face`
  keeps measuring all of them on purpose — whether a camera is worth having is the question
  there — and marks which are processed.

## Confirmed in passing

`retry_seconds: 1.2` (down from 2.5) worked: attempt 2 went from a median of 6.5 s to 4.0 s.

## Tested

All three tools run against the live container (LXC 114): 161 recognitions, 211 photos,
36 events. UI checked in the browser, including the table layout — a global `table{width:100%}`
was pulling the columns apart.