### PR TITLE
Use the live frame when Frigate produces no snapshot at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to FaceID. The Home Assistant app shows this file in the
 update dialog; standalone users can watch GitHub releases.
 
+## 0.22.1 — 2026-09-04
+
+- **`live_hires_fallback` now also covers the case its name promises: no snapshot at all.**
+  It said "on a failed snapshot, ask go2rtc for a full frame", but only handled one of the
+  two ways a snapshot can fail — one that exists and holds no face. When Frigate produced
+  no snapshot, FaceID did nothing: the event never entered the queue (no `has_snapshot`),
+  so even `live_hires_mode: always` never ran. Reported in #14.
+- This matters for setups with `snapshots.required_zones`, where Frigate withholds the
+  snapshot while the person stands plainly in the picture. It could not surface here —
+  our Frigate has no `required_zones`, and `no snapshot from Frigate` appears zero times
+  in 14 days of logs.
+- A recognition from a frame fetched without a snapshot binds nothing to the event: no
+  `sub_label`, no `best_score`. Without the snapshot nothing says who the event is about,
+  which is the same reason `live_hires_mode: always` already behaved that way. It still
+  counts toward presence and fires `faceid/event`.
+- The poll path still requires a snapshot on purpose: it picks up stragglers up to five
+  minutes old, and a frame from now no longer shows that person.
+
 ## 0.22.0 — 2026-09-02
 
 - **A Tools tab with the measurements that used to need a terminal.** Off by default;

--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ that matter most:
 | `hires_enroll` (true) | fetch new review-queue faces from the recording (sharper references) |
 | `clip_fallback` (true) | when a snapshot yields no face at all, scan the recording — on most setups the single biggest gain, see [the pipeline doc](docs/recognition-pipeline.md) |
 | `clip_fallback_cameras` (all) | restrict the fallback to cameras where it actually pays off — the gain depends on the camera angle |
-| `live_hires_fallback` (false) | on a failed snapshot, ask go2rtc for a full-resolution frame right away instead of waiting for the event to end ([details](docs/recognition-pipeline.md)) |
+| `live_hires_fallback` (false) | when the snapshot fails — no face in it, or Frigate not producing one at all — ask go2rtc for a full-resolution frame right away instead of waiting for the event to end. Reports every face in that frame, not just the largest ([details](docs/recognition-pipeline.md)) |
 | `live_hires_fallback_cameras` (all) | restrict that to specific cameras |
 | `live_hires_mode` (fallback) | `always` scans the full frame on every event instead of only after a failed snapshot — measure first, it found nothing extra here |
 | `clip_fallback_frames` (12) | how many frames to sample from the clip |

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -234,7 +234,12 @@ class EventProcessor:
             st["end_time"] = after.get("end_time") or time.time()
         if st["done"] or st["attempts"] >= self.max_attempts:
             return
-        if after.get("has_snapshot") and time.time() - st["last_try"] >= self.retry_secs:
+        # Ohne Snapshot gibt es fuer den Normalweg nichts zu holen. Ist der Vollbild-Weg
+        # fuer diese Kamera aber eingeschaltet, ist genau das der Fall, fuer den er gebaut
+        # wurde: Frigate verweigert den Snapshot an einer Zonenbedingung, waehrend die
+        # Person klar im Bild steht — und FaceID tat bisher gar nichts (Issue #14).
+        if ((after.get("has_snapshot") or self._live_possible(st["camera"]))
+                and time.time() - st["last_try"] >= self.retry_secs):
             st["last_try"] = time.time()
             try:
                 self.queue.put_nowait({"eid": eid})
@@ -263,6 +268,10 @@ class EventProcessor:
         img = self.frigate.snapshot(eid, crop=True)
         if img is None:
             log.info("event %s (%s): no snapshot from Frigate", eid, st["camera"])
+            # always=True, weil ohne Snapshot niemand sagt, WER zu diesem Ereignis
+            # gehoert: melden und zur Anwesenheit zaehlen ja, sub_label nein. Genau
+            # dieselbe Begruendung wie im always-Modus.
+            self._try_live_hires(eid, st, always=True)
             return
         found = self.engine.faces(img)
         face = FaceEngine.best_face(found, min_px=self.min_face_px)
@@ -279,6 +288,12 @@ class EventProcessor:
             self._try_live_hires(eid, st)
             return
         self._handle_face(eid, st, img, face)
+
+    def _live_possible(self, camera: str) -> bool:
+        """Koennte der Vollbild-Weg fuer diese Kamera ueberhaupt greifen?"""
+        if not self.live_hires:
+            return False
+        return not self.live_hires_cameras or camera in self.live_hires_cameras
 
     def _try_live_hires(self, eid: str, st: dict, always: bool = False):
         """Der Snapshot gab nichts her — sofort einen Haupt-Stream-Frame nachschieben.
@@ -409,6 +424,10 @@ class EventProcessor:
         while True:
             time.sleep(self.poll_interval)
             try:
+                # Hier bleibt der Snapshot Pflicht, anders als im MQTT-Weg: der Poll
+                # holt Nachzuegler von vor bis zu fuenf Minuten, und ein Vollbild von
+                # JETZT zeigt die Person von damals nicht mehr. Ohne Snapshot gaebe es
+                # dort also nichts zu gewinnen.
                 batch = self.frigate.events(label="person", has_snapshot=1,
                                             limit=50, after=since - 30)
             except (requests.RequestException, ValueError) as e:

--- a/faceid-addon/CHANGELOG.md
+++ b/faceid-addon/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to FaceID. The Home Assistant app shows this file in the
 update dialog; standalone users can watch GitHub releases.
 
+## 0.22.1 — 2026-09-04
+
+- **`live_hires_fallback` now also covers the case its name promises: no snapshot at all.**
+  It said "on a failed snapshot, ask go2rtc for a full frame", but only handled one of the
+  two ways a snapshot can fail — one that exists and holds no face. When Frigate produced
+  no snapshot, FaceID did nothing: the event never entered the queue (no `has_snapshot`),
+  so even `live_hires_mode: always` never ran. Reported in #14.
+- This matters for setups with `snapshots.required_zones`, where Frigate withholds the
+  snapshot while the person stands plainly in the picture. It could not surface here —
+  our Frigate has no `required_zones`, and `no snapshot from Frigate` appears zero times
+  in 14 days of logs.
+- A recognition from a frame fetched without a snapshot binds nothing to the event: no
+  `sub_label`, no `best_score`. Without the snapshot nothing says who the event is about,
+  which is the same reason `live_hires_mode: always` already behaved that way. It still
+  counts toward presence and fires `faceid/event`.
+- The poll path still requires a snapshot on purpose: it picks up stragglers up to five
+  minutes old, and a frame from now no longer shows that person.
+
 ## 0.22.0 — 2026-09-02
 
 - **A Tools tab with the measurements that used to need a terminal.** Off by default;

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -234,7 +234,12 @@ class EventProcessor:
             st["end_time"] = after.get("end_time") or time.time()
         if st["done"] or st["attempts"] >= self.max_attempts:
             return
-        if after.get("has_snapshot") and time.time() - st["last_try"] >= self.retry_secs:
+        # Ohne Snapshot gibt es fuer den Normalweg nichts zu holen. Ist der Vollbild-Weg
+        # fuer diese Kamera aber eingeschaltet, ist genau das der Fall, fuer den er gebaut
+        # wurde: Frigate verweigert den Snapshot an einer Zonenbedingung, waehrend die
+        # Person klar im Bild steht — und FaceID tat bisher gar nichts (Issue #14).
+        if ((after.get("has_snapshot") or self._live_possible(st["camera"]))
+                and time.time() - st["last_try"] >= self.retry_secs):
             st["last_try"] = time.time()
             try:
                 self.queue.put_nowait({"eid": eid})
@@ -263,6 +268,10 @@ class EventProcessor:
         img = self.frigate.snapshot(eid, crop=True)
         if img is None:
             log.info("event %s (%s): no snapshot from Frigate", eid, st["camera"])
+            # always=True, weil ohne Snapshot niemand sagt, WER zu diesem Ereignis
+            # gehoert: melden und zur Anwesenheit zaehlen ja, sub_label nein. Genau
+            # dieselbe Begruendung wie im always-Modus.
+            self._try_live_hires(eid, st, always=True)
             return
         found = self.engine.faces(img)
         face = FaceEngine.best_face(found, min_px=self.min_face_px)
@@ -279,6 +288,12 @@ class EventProcessor:
             self._try_live_hires(eid, st)
             return
         self._handle_face(eid, st, img, face)
+
+    def _live_possible(self, camera: str) -> bool:
+        """Koennte der Vollbild-Weg fuer diese Kamera ueberhaupt greifen?"""
+        if not self.live_hires:
+            return False
+        return not self.live_hires_cameras or camera in self.live_hires_cameras
 
     def _try_live_hires(self, eid: str, st: dict, always: bool = False):
         """Der Snapshot gab nichts her — sofort einen Haupt-Stream-Frame nachschieben.
@@ -409,6 +424,10 @@ class EventProcessor:
         while True:
             time.sleep(self.poll_interval)
             try:
+                # Hier bleibt der Snapshot Pflicht, anders als im MQTT-Weg: der Poll
+                # holt Nachzuegler von vor bis zu fuenf Minuten, und ein Vollbild von
+                # JETZT zeigt die Person von damals nicht mehr. Ohne Snapshot gaebe es
+                # dort also nichts zu gewinnen.
                 batch = self.frigate.events(label="person", has_snapshot=1,
                                             limit=50, after=since - 30)
             except (requests.RequestException, ValueError) as e:

--- a/faceid-addon/config.yaml
+++ b/faceid-addon/config.yaml
@@ -1,5 +1,5 @@
 name: FaceID
-version: "0.22.0"
+version: "0.22.1"
 slug: faceid
 description: Face recognition for Frigate — trainable gallery, clustered unknown review, HA sensors
 url: https://github.com/SkyTechNerds/faceid


### PR DESCRIPTION
Found while answering #14.

`live_hires_fallback` is documented as *"on a failed snapshot, ask go2rtc for a full-resolution frame right away"*. It only covered one of the two ways a snapshot can fail — one that exists but holds no face. When Frigate produced **no snapshot at all**, FaceID gave up silently.

Two places caused that:

| where | behaviour |
|---|---|
| `mqtt_listener.py` event handler | an event without `has_snapshot` never entered the queue, so `_process` never ran — not even in `always` mode |
| `_process` | if the snapshot API returned nothing, it returned without trying the live frame |

This hits setups with `snapshots.required_zones`, where Frigate withholds the snapshot while the person stands plainly in the picture. It could not show up on my own setup: no `required_zones` here, and `no snapshot from Frigate` appears **zero times in 14 days** of logs.

**Verified by triggering the path, on both versions.** Published an MQTT event with `has_snapshot: false` and an id Frigate does not know, at a moment when nobody was at the camera (last event 67 minutes earlier), so a false recognition was not possible:

- **old code:** zero log lines — the event was ignored entirely
- **new code:**
  ```
  event …-TESTNOSNAP (entrance): no snapshot from Frigate
  event …-TESTNOSNAP (entrance): live frame 2560x1920 has no usable face either
  ```

A recognition from a frame fetched without a snapshot binds nothing to the event — no `sub_label` — because without the snapshot nothing says who the event is about. That is the existing `primary=False` semantics, already used by `always` mode for the same reason.

The poll path deliberately keeps requiring a snapshot: it picks up stragglers up to five minutes old, where a frame from *now* no longer shows that person. Noted in a comment so it does not look like an oversight.

The README line that promised more than the code did is corrected too.