### PR TITLE
One history row per event and person, keeping the best picture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ update dialog; standalone users can watch GitHub releases.
 
 ## 0.22.2 — 2026-09-04
 
-- **The history shows one row per event and person again.** It is titled "What FaceID
+- **The history shows one row per event and named person again** (unknown faces keep one row
+  each — several strangers in a single frame all carry that label, and merging them would
+  swap their pictures against each other). It is titled "What FaceID
   reported", but only the *first* match per person and event is ever reported — the
   `announced` set suppresses the rest. Every further row therefore claimed a notification
   that never happened, and pushed genuine older entries out: 27 such rows out of 200 slots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to FaceID. The Home Assistant app shows this file in the
 update dialog; standalone users can watch GitHub releases.
 
+## 0.22.2 — 2026-09-04
+
+- **The history shows one row per event and person again.** It is titled "What FaceID
+  reported", but only the *first* match per person and event is ever reported — the
+  `announced` set suppresses the rest. Every further row therefore claimed a notification
+  that never happened, and pushed genuine older entries out: 27 such rows out of 200 slots
+  on the reference instance, so the history reached 13% less far back than it should.
+- **Later matches are not discarded, they improve the row.** Checking the stored crops
+  first showed why that matters: all ten sampled duplicate pairs held *different* pictures,
+  sometimes drastically so — 8 KB against 94 KB of the same person, a distant crop against
+  a close one. Those later pictures are exactly what makes a wrong recognition checkable.
+  So a later match now replaces the picture when its score is higher, instead of adding a
+  row, and the card shows "best view 0.687" beside the reported score.
+- Picture and embedding are always replaced together. Keeping them apart would let the
+  "was wrong" analysis run on a different face than the row displays.
+
 ## 0.22.1 — 2026-09-04
 
 - **`live_hires_fallback` now also covers the case its name promises: no snapshot at all.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ update dialog; standalone users can watch GitHub releases.
   first showed why that matters: all ten sampled duplicate pairs held *different* pictures,
   sometimes drastically so — 8 KB against 94 KB of the same person, a distant crop against
   a close one. Those later pictures are exactly what makes a wrong recognition checkable.
-  So a later match now replaces the picture when its score is higher, instead of adding a
-  row, and the card shows "best view 0.687" beside the reported score.
+  So a later match now improves the existing row instead of adding one: it replaces the
+  picture when its score is higher, and the card shows "best view 0.687" beside the
+  reported score. Independently of that, the first match that is actually published takes
+  over the row's score and timestamp even when it scores *lower* — it is the one somebody
+  received, and the card is headed "What FaceID reported".
 - Picture and embedding are always replaced together. Keeping them apart would let the
   "was wrong" analysis run on a different face than the row displays.
 

--- a/app/history.py
+++ b/app/history.py
@@ -32,7 +32,9 @@ class History:
         self.dir = data_dir / "history"
         self.dir.mkdir(parents=True, exist_ok=True)
         self.keep = int(keep)
-        self._lock = threading.Lock()
+        # RLock, nicht Lock: delete() nimmt die Sperre selbst, und ein Aufrufer, der sie
+        # schon haelt, wuerde sich sonst selbst blockieren.
+        self._lock = threading.RLock()
 
     # ---------- Schreiben ----------
 
@@ -188,6 +190,9 @@ class History:
                     n += 1
                 new_img = f"{hid}.v{n}.jpg"
                 if not self._write_image(new_img, crop_bgr):
+                    # Ein halb geschriebenes Bild wuerde bis zum naechsten Aufraeumen
+                    # als Waise herumliegen.
+                    (self.dir / new_img).unlink(missing_ok=True)
                     return False
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
                 payload["best_score"] = round(float(score), 3)
@@ -250,6 +255,9 @@ class History:
             if not (self.dir / self._img_name(m, jf.stem)).exists():
                 continue
             item = {"id": jf.stem, **{k: v for k, v in m.items() if k != "embedding"}}
+            # Den geprueften Namen auch ausliefern: sonst pruefte die Zeile oben den
+            # bereinigten Wert, waehrend die Oberflaeche den rohen aus der Datei bekaeme.
+            item["img"] = self._img_name(m, jf.stem)
             if gallery is not None and m.get("embedding"):
                 try:
                     emb = np.array(m["embedding"], dtype=np.float32)

--- a/app/history.py
+++ b/app/history.py
@@ -36,50 +36,38 @@ class History:
 
     # ---------- Schreiben ----------
 
-    def _write_pair(self, hid: str, crop_bgr, payload: dict) -> bool:
-        """Bild und JSON als Paar schreiben — beide oder keins.
+    def _img_name(self, payload: dict, hid: str) -> str:
+        """Dateiname des Bildes einer Zeile. Aeltere Zeilen kennen das Feld nicht."""
+        return str(payload.get("img") or f"{hid}.jpg")
 
-        ``cv2.imwrite`` wirft bei einem Fehler nicht, es gibt ``False`` zurueck (volle
-        Platte, unbeschreibbarer Pfad). Wird das uebergangen, beschreibt die JSON danach
-        ein Gesicht, das im .jpg gar nicht steht — und genau darauf laeuft spaeter die
-        Fehleranalyse.
-
-        Beide Dateien gehen zuerst nach ``.tmp`` und werden dann per ``os.replace``
-        eingehaengt. Ein Absturz zwischen den beiden ``replace`` bleibt theoretisch
-        moeglich; das Fenster schrumpft damit aber von zwei Schreibvorgaengen auf zwei
-        Metadaten-Operationen.
-        """
-        jpg, js = self.dir / f"{hid}.jpg", self.dir / f"{hid}.json"
-        # Eigenes Unterverzeichnis, und die Zwischendatei behaelt .jpg: OpenCV waehlt das
-        # Format ueber die Endung und schreibt nach ".jpg.tmp" gar nichts. Im selben
-        # Verzeichnis wuerde sie ausserdem vom *.json-Glob mitgezaehlt und taeuchte
-        # kurzzeitig als halbe Zeile im Verlauf auf.
+    def _write_json(self, js: Path, payload: dict) -> bool:
+        """JSON atomar ersetzen — der einzige Moment, in dem eine Zeile umschaltet."""
         tmpdir = self.dir / ".tmp"
         tmpdir.mkdir(exist_ok=True)
-        tmp_jpg, tmp_js = tmpdir / f"{hid}.jpg", tmpdir / f"{hid}.json"
-
-        backup = tmpdir / f"{hid}.prev.jpg"
+        tmp = tmpdir / f"{js.stem}.json"
         try:
-            if not cv2.imwrite(str(tmp_jpg), crop_bgr, [cv2.IMWRITE_JPEG_QUALITY, 88]):
-                log.warning("could not write the history image for %s", hid)
-                return False
-            tmp_js.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
-            # Das Bild wandert zuerst. Scheitert danach die JSON, waere das Bild neu und
-            # die Beschreibung alt — genau der Widerspruch, den diese Funktion verhindern
-            # soll. Deshalb vorher eine Kopie, die in dem Fall zurueckgespielt wird.
-            if jpg.exists():
-                os.replace(jpg, backup)
-            os.replace(tmp_jpg, jpg)
-            try:
-                os.replace(tmp_js, js)
-            except OSError:
-                if backup.exists():
-                    os.replace(backup, jpg)
-                raise
+            tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            os.replace(tmp, js)
             return True
+        except OSError:
+            log.exception("could not write the history entry %s", js.stem)
+            return False
         finally:
-            for f in (tmp_jpg, tmp_js, backup):
-                f.unlink(missing_ok=True)
+            tmp.unlink(missing_ok=True)
+
+    def _write_image(self, name: str, crop_bgr) -> bool:
+        """Bild unter seinem endgueltigen Namen schreiben.
+
+        ``cv2.imwrite`` wirft bei einem Fehler nicht immer, es gibt auch ``False``
+        zurueck (volle Platte, unbeschreibbarer Pfad) — beides muss abgefangen werden,
+        sonst beschriebe die JSON danach ein Bild, das es nicht gibt.
+        """
+        try:
+            return bool(cv2.imwrite(str(self.dir / name), crop_bgr,
+                                    [cv2.IMWRITE_JPEG_QUALITY, 88]))
+        except cv2.error:
+            log.warning("could not encode the history image %s", name)
+            return False
 
     def add(self, crop_bgr, embedding, meta: dict) -> str | None:
         """Einen veroeffentlichten Treffer ablegen. Fehler hier duerfen die Erkennung
@@ -98,7 +86,14 @@ class History:
                     hid = f"{base}_{n}"
                 payload = dict(meta)
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
-                if not self._write_pair(hid, crop_bgr, payload):
+                payload["img"] = f"{hid}.jpg"
+                # Reihenfolge ist der ganze Trick: Erst das Bild, dann die JSON. Gelistet
+                # wird ueber *.json, die Zeile entsteht also genau in dem Moment, in dem
+                # die JSON da ist — und dann liegt das Bild schon bereit.
+                if not self._write_image(payload["img"], crop_bgr):
+                    return None
+                if not self._write_json(self.dir / f"{hid}.json", payload):
+                    (self.dir / payload["img"]).unlink(missing_ok=True)
                     return None
                 self._enforce_cap()
                 return hid
@@ -132,7 +127,13 @@ class History:
                 jf = self.dir / f"{hid}.json"
                 if not jf.exists():
                     return None
-                payload = json.loads(jf.read_text(encoding="utf-8"))
+                try:
+                    payload = json.loads(jf.read_text(encoding="utf-8"))
+                except (ValueError, OSError):
+                    # Unlesbare Zeile: wie eine fehlende behandeln, damit der Aufrufer
+                    # neu anlegt statt sie fuer den Rest des Ereignisses einzufrieren.
+                    log.warning("history entry %s is unreadable — will be replaced", hid)
+                    return None
                 # Ein unlesbarer gespeicherter Wert darf nicht dazu fuehren, dass jede
                 # weitere Verbesserung still unterbleibt — dann lieber ersetzen.
                 try:
@@ -142,14 +143,29 @@ class History:
                     best = 0.0
                 if round(float(score), 3) <= best:
                     return False
+                # Das neue Bild bekommt einen EIGENEN Namen, das alte bleibt liegen.
+                # Damit aendert sich die Zeile ausschliesslich beim Ersetzen der JSON —
+                # scheitert irgendetwas davor oder dabei, zeigt sie unveraendert auf ihr
+                # altes, stimmiges Bild. Ein Zurueckspielen von Sicherungskopien braucht
+                # es dafuer nicht.
+                old_img = self._img_name(payload, hid)
+                n = 1
+                while (self.dir / f"{hid}.v{n}.jpg").exists():
+                    n += 1
+                new_img = f"{hid}.v{n}.jpg"
+                if not self._write_image(new_img, crop_bgr):
+                    return False
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
                 payload["best_score"] = round(float(score), 3)
+                payload["img"] = new_img
                 if attempt is not None:
                     payload["best_attempt"] = attempt
-                # Scheitert das Bild, bleibt die alte Zeile unveraendert stehen — lieber
-                # der aeltere, stimmige Stand als eine Zeile, die auf ein anderes
-                # Gesicht zeigt.
-                return self._write_pair(hid, crop_bgr, payload)
+                if not self._write_json(jf, payload):
+                    (self.dir / new_img).unlink(missing_ok=True)
+                    return False
+                if old_img != new_img:
+                    (self.dir / old_img).unlink(missing_ok=True)
+                return True
         except Exception:
             log.exception("could not update history entry %s", hid)
             return False
@@ -159,7 +175,10 @@ class History:
         files = sorted(self.dir.glob("*.json"), reverse=True)
         for old in files[self.keep:]:
             old.unlink(missing_ok=True)
-            (self.dir / f"{old.stem}.jpg").unlink(missing_ok=True)
+            # Auch die spaeteren Fassungen: eine verbesserte Zeile heisst <id>.vN.jpg,
+            # und wer nur <id>.jpg loescht, laesst Bilder liegen, die *.json nie zaehlt.
+            for img in self.dir.glob(f"{old.stem}.*jpg"):
+                img.unlink(missing_ok=True)
 
     # ---------- Lesen ----------
 
@@ -178,7 +197,7 @@ class History:
                 m = json.loads(jf.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 continue
-            if not (self.dir / f"{jf.stem}.jpg").exists():
+            if not (self.dir / self._img_name(m, jf.stem)).exists():
                 continue
             item = {"id": jf.stem, **{k: v for k, v in m.items() if k != "embedding"}}
             if gallery is not None and m.get("embedding"):
@@ -272,7 +291,8 @@ class History:
 
     def delete(self, hid: str):
         (self.dir / f"{hid}.json").unlink(missing_ok=True)
-        (self.dir / f"{hid}.jpg").unlink(missing_ok=True)
+        for img in self.dir.glob(f"{hid}.*jpg"):
+            img.unlink(missing_ok=True)
 
     def clear(self) -> int:
         n = 0

--- a/app/history.py
+++ b/app/history.py
@@ -45,15 +45,25 @@ class History:
         name = Path(str(payload.get("img") or "")).name
         return name or f"{hid}.jpg"
 
-    def _images_of(self, stem: str):
-        """Alle Bildfassungen einer Zeile: ``<id>.jpg`` und ``<id>.vN.jpg``.
+    @staticmethod
+    def _row_of(img: Path) -> str:
+        """Zu welcher Zeile gehoert dieses Bild? ``<id>.jpg`` oder ``<id>.vN.jpg``.
 
-        Bewusst ohne ``glob``: die Kennung stuende dort als Muster, und ein ``*`` oder
-        ``[`` darin traefe fremde Zeilen.
+        Die einzige Stelle, die den Namensaufbau kennt — vorher fragten Verdraengung
+        und Waisensuche dasselbe auf zwei Arten.
         """
-        for f in self.dir.iterdir():
-            if f.suffix == ".jpg" and (f.name == f"{stem}.jpg"
-                                       or f.name.startswith(f"{stem}.v")):
+        name = img.name[:-len(".jpg")]
+        head, sep, tail = name.rpartition(".v")
+        return head if sep and tail.isdigit() else name
+
+    def _images_of(self, stem: str):
+        """Alle Bildfassungen einer Zeile.
+
+        Bewusst ohne Muster aus der Kennung: die ist Nutzdatum, und ein ``*`` oder
+        ``[`` darin traefe als Glob fremde Zeilen.
+        """
+        for f in self.dir.glob("*.jpg"):
+            if self._row_of(f) == stem:
                 yield f
 
     def _write_json(self, js: Path, payload: dict) -> bool:
@@ -188,7 +198,13 @@ class History:
                     (self.dir / new_img).unlink(missing_ok=True)
                     return False
                 if old_img != new_img:
-                    (self.dir / old_img).unlink(missing_ok=True)
+                    # Nur noch Aufraeumen — die Zeile steht bereits richtig. Ein Fehler
+                    # hier darf nicht als Fehlschlag zurueckgemeldet werden; das Bild
+                    # holt spaetestens der naechste Durchlauf von _enforce_cap.
+                    try:
+                        (self.dir / old_img).unlink(missing_ok=True)
+                    except OSError:
+                        log.warning("could not remove the superseded image %s", old_img)
                 return True
         except Exception:
             log.exception("could not update history entry %s", hid)
@@ -196,20 +212,17 @@ class History:
 
     def _enforce_cap(self):
         """Aelteste ueber dem Limit entfernen (Aufrufer haelt das Lock)."""
-        files = sorted(self.dir.glob("*.json"), reverse=True)
-        for old in files[self.keep:]:
+        for old in sorted(self.dir.glob("*.json"), reverse=True)[self.keep:]:
             old.unlink(missing_ok=True)
-            # Auch die spaeteren Fassungen: eine verbesserte Zeile heisst <id>.vN.jpg,
-            # und wer nur <id>.jpg loescht, laesst Bilder liegen, die *.json nie zaehlt.
-            for img in self._images_of(old.stem):
-                img.unlink(missing_ok=True)
-        # Bilder ohne Zeile einsammeln. Gelistet wird ueber *.json, ein Bild ohne JSON
-        # wuerde also nie wieder gezaehlt und nie geloescht — es waere unsichtbarer
-        # Ballast. Gefahrlos, weil beide Schreibwege das Lock halten und ein Bild nur
-        # waehrenddessen kurz ohne seine Zeile existiert.
-        known = {img for j in self.dir.glob("*.json") for img in self._images_of(j.stem)}
+        # Danach EIN Durchlauf ueber die Bilder: das raeumt die eben verdraengten Zeilen
+        # mit weg und ebenso Bilder, die auf anderem Weg ihre Zeile verloren haben — die
+        # wuerden sonst nie wieder gezaehlt, weil ueber *.json gelistet wird.
+        # Vorher lief _images_of je Zeile einmal ueber das ganze Verzeichnis.
+        # Gefahrlos, weil beide Schreibwege das Lock halten und ein Bild nur innerhalb
+        # dieses Abschnitts kurz ohne seine Zeile existiert.
+        stems = {j.stem for j in self.dir.glob("*.json")}
         for img in self.dir.glob("*.jpg"):
-            if img not in known:
+            if self._row_of(img) not in stems:
                 img.unlink(missing_ok=True)
 
     # ---------- Lesen ----------
@@ -322,9 +335,13 @@ class History:
     # ---------- Aufraeumen ----------
 
     def delete(self, hid: str):
-        (self.dir / f"{hid}.json").unlink(missing_ok=True)
-        for img in self._images_of(hid):
-            img.unlink(missing_ok=True)
+        # Unter derselben Sperre wie die Schreibwege: sonst koennte zwischen dem
+        # Entfernen der Zeile und ihrer Bilder ein laufendes improve() ein neues Bild
+        # anlegen, das anschliessend niemandem mehr gehoert.
+        with self._lock:
+            (self.dir / f"{hid}.json").unlink(missing_ok=True)
+            for img in self._images_of(hid):
+                img.unlink(missing_ok=True)
 
     def clear(self) -> int:
         n = 0

--- a/app/history.py
+++ b/app/history.py
@@ -63,7 +63,7 @@ class History:
         ``[`` darin traefe als Glob fremde Zeilen.
         """
         for f in self.dir.glob("*.jpg"):
-            if self._row_of(f) == stem:
+            if f.stem == stem or self._row_of(f) == stem:
                 yield f
 
     def _write_json(self, js: Path, payload: dict) -> bool:
@@ -222,7 +222,12 @@ class History:
         # dieses Abschnitts kurz ohne seine Zeile existiert.
         stems = {j.stem for j in self.dir.glob("*.json")}
         for img in self.dir.glob("*.jpg"):
-            if self._row_of(img) not in stems:
+            # Erst der volle Name: gaebe es je eine Kennung, die selbst auf ".v<Ziffern>"
+            # endet, wuerde _row_of sie einer fremden Zeile zuschlagen und ihr lebendes
+            # Bild loeschen. Die Kennungen entstehen zwar aus time.time() und koennen
+            # keinen Punkt enthalten — aber das hier ist ein Aufraeumpfad, und der darf
+            # sich auf keine Annahme stuetzen, die er selbst nicht prueft.
+            if img.stem not in stems and self._row_of(img) not in stems:
                 img.unlink(missing_ok=True)
 
     # ---------- Lesen ----------

--- a/app/history.py
+++ b/app/history.py
@@ -58,17 +58,28 @@ class History:
         tmpdir.mkdir(exist_ok=True)
         tmp_jpg, tmp_js = tmpdir / f"{hid}.jpg", tmpdir / f"{hid}.json"
 
+        backup = tmpdir / f"{hid}.prev.jpg"
         try:
             if not cv2.imwrite(str(tmp_jpg), crop_bgr, [cv2.IMWRITE_JPEG_QUALITY, 88]):
                 log.warning("could not write the history image for %s", hid)
                 return False
             tmp_js.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            # Das Bild wandert zuerst. Scheitert danach die JSON, waere das Bild neu und
+            # die Beschreibung alt — genau der Widerspruch, den diese Funktion verhindern
+            # soll. Deshalb vorher eine Kopie, die in dem Fall zurueckgespielt wird.
+            if jpg.exists():
+                os.replace(jpg, backup)
             os.replace(tmp_jpg, jpg)
-            os.replace(tmp_js, js)
+            try:
+                os.replace(tmp_js, js)
+            except OSError:
+                if backup.exists():
+                    os.replace(backup, jpg)
+                raise
             return True
         finally:
-            tmp_jpg.unlink(missing_ok=True)
-            tmp_js.unlink(missing_ok=True)
+            for f in (tmp_jpg, tmp_js, backup):
+                f.unlink(missing_ok=True)
 
     def add(self, crop_bgr, embedding, meta: dict) -> str | None:
         """Einen veroeffentlichten Treffer ablegen. Fehler hier duerfen die Erkennung
@@ -109,6 +120,10 @@ class History:
         eigentliche Fehler: Die Analyse liefe sonst auf einem anderen Gesicht, als die
         Zeile zeigt. ``score``/``ts`` bleiben die der Meldung, damit der Verlauf weiter
         beantwortet, womit sie ausgeloest wurde.
+
+        Rueckgabe: ``True`` uebernommen, ``False`` nicht besser, ``None`` die Zeile gibt
+        es nicht mehr (vom Limit verdraengt) — dann muss der Aufrufer neu anlegen, sonst
+        faellt die Erkennung stillschweigend aus dem Verlauf.
         """
         if self.keep <= 0 or crop_bgr is None or embedding is None or not hid:
             return False
@@ -116,9 +131,16 @@ class History:
             with self._lock:
                 jf = self.dir / f"{hid}.json"
                 if not jf.exists():
-                    return False
+                    return None
                 payload = json.loads(jf.read_text(encoding="utf-8"))
-                if float(score) <= float(payload.get("best_score", payload.get("score", 0))):
+                # Ein unlesbarer gespeicherter Wert darf nicht dazu fuehren, dass jede
+                # weitere Verbesserung still unterbleibt — dann lieber ersetzen.
+                try:
+                    best = round(float(payload.get("best_score",
+                                                   payload.get("score", 0))), 3)
+                except (TypeError, ValueError):
+                    best = 0.0
+                if round(float(score), 3) <= best:
                     return False
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
                 payload["best_score"] = round(float(score), 3)

--- a/app/history.py
+++ b/app/history.py
@@ -179,6 +179,14 @@ class History:
             # und wer nur <id>.jpg loescht, laesst Bilder liegen, die *.json nie zaehlt.
             for img in self.dir.glob(f"{old.stem}.*jpg"):
                 img.unlink(missing_ok=True)
+        # Bilder ohne Zeile einsammeln. Gelistet wird ueber *.json, ein Bild ohne JSON
+        # wuerde also nie wieder gezaehlt und nie geloescht — es waere unsichtbarer
+        # Ballast. Gefahrlos, weil beide Schreibwege das Lock halten und ein Bild nur
+        # waehrenddessen kurz ohne seine Zeile existiert.
+        stems = {p.stem for p in self.dir.glob("*.json")}
+        for img in self.dir.glob("*.jpg"):
+            if img.name.split(".", 1)[0] not in stems:
+                img.unlink(missing_ok=True)
 
     # ---------- Lesen ----------
 

--- a/app/history.py
+++ b/app/history.py
@@ -37,8 +37,24 @@ class History:
     # ---------- Schreiben ----------
 
     def _img_name(self, payload: dict, hid: str) -> str:
-        """Dateiname des Bildes einer Zeile. Aeltere Zeilen kennen das Feld nicht."""
-        return str(payload.get("img") or f"{hid}.jpg")
+        """Dateiname des Bildes einer Zeile. Aeltere Zeilen kennen das Feld nicht.
+
+        Nur der Basisname wird uebernommen: der Wert stammt aus einer Datei, und ein
+        Pfad darin duerfte nie mit ``self.dir`` zusammengesetzt werden.
+        """
+        name = Path(str(payload.get("img") or "")).name
+        return name or f"{hid}.jpg"
+
+    def _images_of(self, stem: str):
+        """Alle Bildfassungen einer Zeile: ``<id>.jpg`` und ``<id>.vN.jpg``.
+
+        Bewusst ohne ``glob``: die Kennung stuende dort als Muster, und ein ``*`` oder
+        ``[`` darin traefe fremde Zeilen.
+        """
+        for f in self.dir.iterdir():
+            if f.suffix == ".jpg" and (f.name == f"{stem}.jpg"
+                                       or f.name.startswith(f"{stem}.v")):
+                yield f
 
     def _write_json(self, js: Path, payload: dict) -> bool:
         """JSON atomar ersetzen — der einzige Moment, in dem eine Zeile umschaltet."""
@@ -49,7 +65,9 @@ class History:
             tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
             os.replace(tmp, js)
             return True
-        except OSError:
+        except (OSError, TypeError, ValueError):
+            # json.dumps scheitert an nicht serialisierbaren Werten mit TypeError —
+            # faengt man nur OSError, reisst es die ganze Erkennung mit.
             log.exception("could not write the history entry %s", js.stem)
             return False
         finally:
@@ -101,7 +119,8 @@ class History:
             log.exception("could not record a recognition in the history")
             return None
 
-    def improve(self, hid: str, crop_bgr, embedding, score: float, attempt=None) -> bool:
+    def improve(self, hid: str, crop_bgr, embedding, score: float,
+                attempt=None) -> bool | None:
         """Einen spaeteren, besseren Treffer derselben Person im selben Ereignis
         einarbeiten — ohne eine zweite Zeile anzulegen.
 
@@ -116,9 +135,14 @@ class History:
         Zeile zeigt. ``score``/``ts`` bleiben die der Meldung, damit der Verlauf weiter
         beantwortet, womit sie ausgeloest wurde.
 
-        Rueckgabe: ``True`` uebernommen, ``False`` nicht besser, ``None`` die Zeile gibt
-        es nicht mehr (vom Limit verdraengt) — dann muss der Aufrufer neu anlegen, sonst
-        faellt die Erkennung stillschweigend aus dem Verlauf.
+        Rueckgabe: ``True`` uebernommen; ``False`` nicht uebernommen, die Zeile steht
+        unveraendert (nicht besser, oder das Schreiben schlug fehl); ``None`` die Zeile
+        gibt es nicht mehr oder sie ist unlesbar — dann muss der Aufrufer neu anlegen,
+        sonst faellt die Erkennung stillschweigend aus dem Verlauf.
+
+        Ein unerwarteter Fehler ergibt bewusst ``False`` und nicht ``None``: die Zeile
+        existiert ja noch, und ein Neuanlegen brauechte genau das Duplikat, das diese
+        Funktion vermeiden soll.
         """
         if self.keep <= 0 or crop_bgr is None or embedding is None or not hid:
             return False
@@ -177,15 +201,15 @@ class History:
             old.unlink(missing_ok=True)
             # Auch die spaeteren Fassungen: eine verbesserte Zeile heisst <id>.vN.jpg,
             # und wer nur <id>.jpg loescht, laesst Bilder liegen, die *.json nie zaehlt.
-            for img in self.dir.glob(f"{old.stem}.*jpg"):
+            for img in self._images_of(old.stem):
                 img.unlink(missing_ok=True)
         # Bilder ohne Zeile einsammeln. Gelistet wird ueber *.json, ein Bild ohne JSON
         # wuerde also nie wieder gezaehlt und nie geloescht — es waere unsichtbarer
         # Ballast. Gefahrlos, weil beide Schreibwege das Lock halten und ein Bild nur
         # waehrenddessen kurz ohne seine Zeile existiert.
-        stems = {p.stem for p in self.dir.glob("*.json")}
+        known = {img for j in self.dir.glob("*.json") for img in self._images_of(j.stem)}
         for img in self.dir.glob("*.jpg"):
-            if img.name.split(".", 1)[0] not in stems:
+            if img not in known:
                 img.unlink(missing_ok=True)
 
     # ---------- Lesen ----------
@@ -299,7 +323,7 @@ class History:
 
     def delete(self, hid: str):
         (self.dir / f"{hid}.json").unlink(missing_ok=True)
-        for img in self.dir.glob(f"{hid}.*jpg"):
+        for img in self._images_of(hid):
             img.unlink(missing_ok=True)
 
     def clear(self) -> int:

--- a/app/history.py
+++ b/app/history.py
@@ -14,6 +14,7 @@ und was passiert waere, haette es dieses Foto nicht gegeben.
 """
 import json
 import logging
+import os
 import threading
 import time
 from pathlib import Path
@@ -35,6 +36,33 @@ class History:
 
     # ---------- Schreiben ----------
 
+    def _write_pair(self, hid: str, crop_bgr, payload: dict) -> bool:
+        """Bild und JSON als Paar schreiben — beide oder keins.
+
+        ``cv2.imwrite`` wirft bei einem Fehler nicht, es gibt ``False`` zurueck (volle
+        Platte, unbeschreibbarer Pfad). Wird das uebergangen, beschreibt die JSON danach
+        ein Gesicht, das im .jpg gar nicht steht — und genau darauf laeuft spaeter die
+        Fehleranalyse.
+
+        Beide Dateien gehen zuerst nach ``.tmp`` und werden dann per ``os.replace``
+        eingehaengt. Ein Absturz zwischen den beiden ``replace`` bleibt theoretisch
+        moeglich; das Fenster schrumpft damit aber von zwei Schreibvorgaengen auf zwei
+        Metadaten-Operationen.
+        """
+        jpg, js = self.dir / f"{hid}.jpg", self.dir / f"{hid}.json"
+        tmp_jpg, tmp_js = jpg.with_suffix(".jpg.tmp"), js.with_suffix(".json.tmp")
+        try:
+            if not cv2.imwrite(str(tmp_jpg), crop_bgr, [cv2.IMWRITE_JPEG_QUALITY, 88]):
+                log.warning("could not write the history image for %s", hid)
+                return False
+            tmp_js.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            os.replace(tmp_jpg, jpg)
+            os.replace(tmp_js, js)
+            return True
+        finally:
+            tmp_jpg.unlink(missing_ok=True)
+            tmp_js.unlink(missing_ok=True)
+
     def add(self, crop_bgr, embedding, meta: dict) -> str | None:
         """Einen veroeffentlichten Treffer ablegen. Fehler hier duerfen die Erkennung
         nie stoeren — im Zweifel wird nichts gespeichert und weitergearbeitet."""
@@ -50,11 +78,10 @@ class History:
                 while (self.dir / f"{hid}.json").exists():
                     n += 1
                     hid = f"{base}_{n}"
-                cv2.imwrite(str(self.dir / f"{hid}.jpg"), crop_bgr, [cv2.IMWRITE_JPEG_QUALITY, 88])
                 payload = dict(meta)
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
-                (self.dir / f"{hid}.json").write_text(
-                    json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+                if not self._write_pair(hid, crop_bgr, payload):
+                    return None
                 self._enforce_cap()
                 return hid
         except Exception:
@@ -86,14 +113,14 @@ class History:
                 payload = json.loads(jf.read_text(encoding="utf-8"))
                 if float(score) <= float(payload.get("best_score", payload.get("score", 0))):
                     return False
-                cv2.imwrite(str(self.dir / f"{hid}.jpg"), crop_bgr,
-                            [cv2.IMWRITE_JPEG_QUALITY, 88])
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
                 payload["best_score"] = round(float(score), 3)
                 if attempt is not None:
                     payload["best_attempt"] = attempt
-                jf.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
-                return True
+                # Scheitert das Bild, bleibt die alte Zeile unveraendert stehen — lieber
+                # der aeltere, stimmige Stand als eine Zeile, die auf ein anderes
+                # Gesicht zeigt.
+                return self._write_pair(hid, crop_bgr, payload)
         except Exception:
             log.exception("could not update history entry %s", hid)
             return False

--- a/app/history.py
+++ b/app/history.py
@@ -50,7 +50,14 @@ class History:
         Metadaten-Operationen.
         """
         jpg, js = self.dir / f"{hid}.jpg", self.dir / f"{hid}.json"
-        tmp_jpg, tmp_js = jpg.with_suffix(".jpg.tmp"), js.with_suffix(".json.tmp")
+        # Eigenes Unterverzeichnis, und die Zwischendatei behaelt .jpg: OpenCV waehlt das
+        # Format ueber die Endung und schreibt nach ".jpg.tmp" gar nichts. Im selben
+        # Verzeichnis wuerde sie ausserdem vom *.json-Glob mitgezaehlt und taeuchte
+        # kurzzeitig als halbe Zeile im Verlauf auf.
+        tmpdir = self.dir / ".tmp"
+        tmpdir.mkdir(exist_ok=True)
+        tmp_jpg, tmp_js = tmpdir / f"{hid}.jpg", tmpdir / f"{hid}.json"
+
         try:
             if not cv2.imwrite(str(tmp_jpg), crop_bgr, [cv2.IMWRITE_JPEG_QUALITY, 88]):
                 log.warning("could not write the history image for %s", hid)

--- a/app/history.py
+++ b/app/history.py
@@ -132,7 +132,7 @@ class History:
             return None
 
     def improve(self, hid: str, crop_bgr, embedding, score: float,
-                attempt=None) -> bool | None:
+                attempt=None, ts=None, reported: bool = False) -> bool | None:
         """Einen spaeteren, besseren Treffer derselben Person im selben Ereignis
         einarbeiten — ohne eine zweite Zeile anzulegen.
 
@@ -155,9 +155,15 @@ class History:
         Ein unerwarteter Fehler ergibt bewusst ``False`` und nicht ``None``: die Zeile
         existiert ja noch, und ein Neuanlegen brauechte genau das Duplikat, das diese
         Funktion vermeiden soll.
+
+        ``reported`` uebergibt, ob DIESE Erkennung hinausging. Trug die Zeile bisher eine
+        Erkennung, die nie gemeldet wurde (Broker weg), uebernimmt die erste tatsaechlich
+        gemeldete deren ``score``/``ts`` — sonst behauptete eine mit "was FaceID gemeldet
+        hat" ueberschriebene Karte einen Wert, den nie jemand bekommen hat.
         """
         if self.keep <= 0 or crop_bgr is None or embedding is None or not hid:
             return False
+        new_img = None
         try:
             with self._lock:
                 jf = self.dir / f"{hid}.json"
@@ -177,7 +183,11 @@ class History:
                                                    payload.get("score", 0))), 3)
                 except (TypeError, ValueError):
                     best = 0.0
-                if round(float(score), 3) <= best:
+                # Die erste wirklich gemeldete Erkennung darf die Zeile auch dann
+                # uebernehmen, wenn ihr Wert niedriger ist: sie ist die, die zaehlt.
+                takeover = bool(reported) and not payload.get("reported")
+                better = round(float(score), 3) > best
+                if not better and not takeover:
                     return False
                 # Das neue Bild bekommt einen EIGENEN Namen, das alte bleibt liegen.
                 # Damit aendert sich die Zeile ausschliesslich beim Ersetzen der JSON —
@@ -185,24 +195,32 @@ class History:
                 # altes, stimmiges Bild. Ein Zurueckspielen von Sicherungskopien braucht
                 # es dafuer nicht.
                 old_img = self._img_name(payload, hid)
-                n = 1
-                while (self.dir / f"{hid}.v{n}.jpg").exists():
-                    n += 1
-                new_img = f"{hid}.v{n}.jpg"
-                if not self._write_image(new_img, crop_bgr):
-                    # Ein halb geschriebenes Bild wuerde bis zum naechsten Aufraeumen
-                    # als Waise herumliegen.
-                    (self.dir / new_img).unlink(missing_ok=True)
-                    return False
-                payload["embedding"] = [round(float(v), 6) for v in embedding]
-                payload["best_score"] = round(float(score), 3)
-                payload["img"] = new_img
-                if attempt is not None:
-                    payload["best_attempt"] = attempt
+                if better:
+                    n = 1
+                    while (self.dir / f"{hid}.v{n}.jpg").exists():
+                        n += 1
+                    new_img = f"{hid}.v{n}.jpg"
+                    if not self._write_image(new_img, crop_bgr):
+                        # Ein halb geschriebenes Bild wuerde bis zum naechsten
+                        # Aufraeumen als Waise herumliegen.
+                        (self.dir / new_img).unlink(missing_ok=True)
+                        return False
+                    payload["embedding"] = [round(float(v), 6) for v in embedding]
+                    payload["best_score"] = round(float(score), 3)
+                    payload["img"] = new_img
+                    if attempt is not None:
+                        payload["best_attempt"] = attempt
+                if takeover:
+                    payload["reported"] = True
+                    payload["score"] = round(float(score), 3)
+                    if ts is not None:
+                        payload["ts"] = ts
+                    if attempt is not None:
+                        payload["attempt"] = attempt
                 if not self._write_json(jf, payload):
                     (self.dir / new_img).unlink(missing_ok=True)
                     return False
-                if old_img != new_img:
+                if new_img and old_img != new_img:
                     # Nur noch Aufraeumen — die Zeile steht bereits richtig. Ein Fehler
                     # hier darf nicht als Fehlschlag zurueckgemeldet werden; das Bild
                     # holt spaetestens der naechste Durchlauf von _enforce_cap.
@@ -212,6 +230,10 @@ class History:
                         log.warning("could not remove the superseded image %s", old_img)
                 return True
         except Exception:
+            # Ein schon geschriebenes neues Bild wuerde sonst liegen bleiben: der
+            # Aufraeumlauf haelt es fuer gueltig, weil seine Zeile ja noch existiert.
+            if new_img:
+                (self.dir / new_img).unlink(missing_ok=True)
             log.exception("could not update history entry %s", hid)
             return False
 

--- a/app/history.py
+++ b/app/history.py
@@ -61,6 +61,43 @@ class History:
             log.exception("could not record a recognition in the history")
             return None
 
+    def improve(self, hid: str, crop_bgr, embedding, score: float, attempt=None) -> bool:
+        """Einen spaeteren, besseren Treffer derselben Person im selben Ereignis
+        einarbeiten — ohne eine zweite Zeile anzulegen.
+
+        Gemeldet wurde nur der erste Treffer (das ``announced``-Set unterdrueckt
+        weitere), eine zweite Zeile behauptete also eine Meldung, die es nie gab. Der
+        spaetere Ausschnitt ist aber haeufig der weit bessere Beleg — gemessen bis zu
+        94 KB gegen 8 KB derselben Person —, und genau der macht eine Fehlerkennung
+        nachpruefbar. Also: eine Zeile, aber mit dem besten Bild.
+
+        Bild UND Embedding werden zusammen ersetzt. Sie getrennt zu behandeln waere der
+        eigentliche Fehler: Die Analyse liefe sonst auf einem anderen Gesicht, als die
+        Zeile zeigt. ``score``/``ts`` bleiben die der Meldung, damit der Verlauf weiter
+        beantwortet, womit sie ausgeloest wurde.
+        """
+        if self.keep <= 0 or crop_bgr is None or embedding is None or not hid:
+            return False
+        try:
+            with self._lock:
+                jf = self.dir / f"{hid}.json"
+                if not jf.exists():
+                    return False
+                payload = json.loads(jf.read_text(encoding="utf-8"))
+                if float(score) <= float(payload.get("best_score", payload.get("score", 0))):
+                    return False
+                cv2.imwrite(str(self.dir / f"{hid}.jpg"), crop_bgr,
+                            [cv2.IMWRITE_JPEG_QUALITY, 88])
+                payload["embedding"] = [round(float(v), 6) for v in embedding]
+                payload["best_score"] = round(float(score), 3)
+                if attempt is not None:
+                    payload["best_attempt"] = attempt
+                jf.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+                return True
+        except Exception:
+            log.exception("could not update history entry %s", hid)
+            return False
+
     def _enforce_cap(self):
         """Aelteste ueber dem Limit entfernen (Aufrufer haelt das Lock)."""
         files = sorted(self.dir.glob("*.json"), reverse=True)

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -608,15 +608,15 @@ class EventProcessor:
         # Eine MENGE, kein einzelner Name: in einem Vollbild koennen mehrere Bekannte
         # stehen, die sich sonst gegenseitig ueberschreiben und abwechselnd neu gemeldet
         # wuerden — genau die Doppelmeldung, die diese Stelle verhindern soll.
+        # Nur vermerken, was wirklich hinausging: waere der Name schon beim fehlenden
+        # Client als gemeldet markiert, bliebe er es fuer dieses Ereignis auch nach dem
+        # Wiederverbinden — ein spaeterer Treffer koennte die Meldung nicht mehr
+        # nachholen. Der Verlauf fuehrt seine eigene Merkliste (hids, s. unten).
         announced = st.setdefault("announced", set())
-        first_time = name not in announced
-        if first_time:
-            # Die Merkliste unabhaengig vom MQTT-Client fuehren: sie steuert auch den
-            # Verlauf, und ohne Client waere dort sonst jeder Treffer eine neue Zeile.
+        if self.client and name not in announced:
             announced.add(name)
-            if self.client:
-                self.client.publish(f"{self.prefix}/event",
-                                    json.dumps(payload, ensure_ascii=False))
+            self.client.publish(f"{self.prefix}/event",
+                                json.dumps(payload, ensure_ascii=False))
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist
@@ -634,15 +634,20 @@ class EventProcessor:
         # ist aber oft der bessere Beleg, deshalb ersetzt er das Bild, statt verworfen zu
         # werden.
         if self.history is not None and crop is not None:
+            # Die vorhandene Zeile ist die Merkliste: gibt es noch keine — auch weil der
+            # erste Treffer ohne Ausschnitt kam oder das Anlegen scheiterte —, wird
+            # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus
+            # dem Verlauf, obwohl sie stattgefunden hat.
             hids = st.setdefault("hids", {})
-            if first_time:
+            hid = hids.get(name)
+            if hid is None:
                 hid = self.history.add(
                     crop, emb, {k: v for k, v in payload.items() if k != "ts"}
                     | {"ts": payload["ts"], "attempt": st.get("attempts")})
                 if hid:
                     hids[name] = hid
-            elif hids.get(name):
-                self.history.improve(hids[name], crop, emb, score,
+            else:
+                self.history.improve(hid, crop, emb, score,
                                      attempt=st.get("attempts"))
 
     def _publish_presence(self, cam: str, last: dict | None = None):

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -660,10 +660,11 @@ class EventProcessor:
         # nichts. (Frueher entschied das ein Gate hier — das warf im Broker-Ausfall die
         # ganze Erkennung weg.)
         if self.history is not None and crop is not None:
-            # ``sent`` und nicht "die Person steht in announced": letzteres ist auch fuer
-            # jeden spaeteren Treffer wahr, der selbst nichts mehr meldet. Die Marke in der
-            # Zeile beantwortet genau eine Frage — ging DIESE Erkennung hinaus?
-            published = sent
+            # Die Marke beantwortet die Frage auf Ereignis-Ebene: ging fuer diese Person
+            # in diesem Ereignis eine Meldung hinaus? ``sent`` allein reicht nicht — hatte
+            # der erste, tatsaechlich gemeldete Treffer keinen Ausschnitt, entsteht die
+            # Zeile erst spaeter und truege faelschlich "nicht gemeldet".
+            published = sent or name in announced
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -636,11 +636,20 @@ class EventProcessor:
                     # sub_label eingeschlossen —, obwohl nur die Meldung misslang.
                     log.exception("could not publish the recognition for %s", name)
                     info = None
-                # Kein rc am Ergebnis: als Fehlschlag werten. Ein fehlendes Feld ist
-                # keine Zusage, und die Marke soll im Zweifel zu wenig behaupten.
-                if getattr(info, "rc", None) == mqtt.MQTT_ERR_SUCCESS:
+                rc = getattr(info, "rc", None)
+                # Zwei verschiedene Fragen, deshalb zwei Merker:
+                #
+                # ``announced`` verhindert die Doppelmeldung. Eingereiht ist verschickt —
+                # bei MQTT_ERR_AGAIN (voller Socket-Puffer) liegt das Paket in der
+                # Warteschlange und geht ueber den Netzwerk-Thread hinaus. Nur wo
+                # feststeht, dass NICHTS eingereiht wurde, darf ein spaeterer Treffer es
+                # erneut senden.
+                #
+                # ``sent`` markiert die Verlaufszeile und verlangt echten Erfolg: dort
+                # soll im Zweifel zu wenig behauptet werden, nicht zu viel.
+                if rc not in (mqtt.MQTT_ERR_NO_CONN, mqtt.MQTT_ERR_QUEUE_SIZE):
                     announced.add(name)
-                    sent = True
+                sent = rc == mqtt.MQTT_ERR_SUCCESS
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -609,9 +609,14 @@ class EventProcessor:
         # stehen, die sich sonst gegenseitig ueberschreiben und abwechselnd neu gemeldet
         # wuerden — genau die Doppelmeldung, die diese Stelle verhindern soll.
         announced = st.setdefault("announced", set())
-        if self.client and name not in announced:
+        first_time = name not in announced
+        if first_time:
+            # Die Merkliste unabhaengig vom MQTT-Client fuehren: sie steuert auch den
+            # Verlauf, und ohne Client waere dort sonst jeder Treffer eine neue Zeile.
             announced.add(name)
-            self.client.publish(f"{self.prefix}/event", json.dumps(payload, ensure_ascii=False))
+            if self.client:
+                self.client.publish(f"{self.prefix}/event",
+                                    json.dumps(payload, ensure_ascii=False))
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist
@@ -622,9 +627,23 @@ class EventProcessor:
         # Den TATSAECHLICH benutzten Ausschnitt festhalten. Der Frigate-Snapshot wird
         # waehrend des Ereignisses fortlaufend ersetzt und zeigt spaeter oft einen anderen
         # Moment — eine Nachpruefung an ihm fuehrt in die Irre. Siehe app/history.py.
+        # EINE Zeile je (Ereignis, Person). Ein spaeterer Treffer derselben Person meldet
+        # nichts mehr (s. oben) — eine zweite Zeile behauptete also eine Meldung, die es
+        # nie gab, und verdraengte dabei aeltere echte Eintraege: gemessen 27 solcher
+        # Zeilen bei 200 Plaetzen, also 13 % weniger Reichweite. Der spaetere Ausschnitt
+        # ist aber oft der bessere Beleg, deshalb ersetzt er das Bild, statt verworfen zu
+        # werden.
         if self.history is not None and crop is not None:
-            self.history.add(crop, emb, {k: v for k, v in payload.items() if k != "ts"}
-                             | {"ts": payload["ts"], "attempt": st.get("attempts")})
+            hids = st.setdefault("hids", {})
+            if first_time:
+                hid = self.history.add(
+                    crop, emb, {k: v for k, v in payload.items() if k != "ts"}
+                    | {"ts": payload["ts"], "attempt": st.get("attempts")})
+                if hid:
+                    hids[name] = hid
+            elif hids.get(name):
+                self.history.improve(hids[name], crop, emb, score,
+                                     attempt=st.get("attempts"))
 
     def _publish_presence(self, cam: str, last: dict | None = None):
         """Sensor-State = alle im Fenster gesehenen Personen ('Christian, Juli' / 'niemand')."""

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -635,8 +635,13 @@ class EventProcessor:
                     # Ungefangen risse das die ganze Erkennung mit — Sensor, Verlauf und
                     # sub_label eingeschlossen —, obwohl nur die Meldung misslang.
                     log.exception("could not publish the recognition for %s", name)
-                    info = None
-                rc = getattr(info, "rc", None)
+                    # Wirft der Aufruf, wurde garantiert nichts eingereiht — also wie ein
+                    # fehlender Broker behandeln, damit ein spaeterer Treffer die Meldung
+                    # nachholen darf. Ein neutrales None waere hier falsch: es zaehlte
+                    # unten als "vielleicht verschickt" und sperrte die Wiederholung.
+                    info, rc = None, mqtt.MQTT_ERR_NO_CONN
+                else:
+                    rc = getattr(info, "rc", None)
                 # Zwei verschiedene Fragen, deshalb zwei Merker:
                 #
                 # ``announced`` verhindert die Doppelmeldung. Eingereiht ist verschickt —

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -666,7 +666,11 @@ class EventProcessor:
             # in diesem Ereignis eine Meldung hinaus? ``sent`` allein reicht nicht — hatte
             # der erste, tatsaechlich gemeldete Treffer keinen Ausschnitt, entsteht die
             # Zeile erst spaeter und truege faelschlich "nicht gemeldet".
-            published = sent or name in announced
+            # Bei benannten Personen traegt EINE Zeile das ganze Ereignis, also zaehlt
+            # die Ereignis-Ebene. Unbekannte behalten je Erkennung eine eigene Zeile
+            # (s. unten) — dort gilt deshalb nur, ob GENAU DIESE Meldung hinausging;
+            # gemeldet wird ohnehin nur die erste, alle weiteren sperrt ``announced``.
+            published = sent if name == "unknown" else (sent or name in announced)
             # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Meldet ausgerechnet
             # ein Treffer OHNE Ausschnitt als erster, laeuft dieser Block gar nicht, und
             # die Marke bleibt bis zum naechsten Treffer mit Bild auf "nicht gemeldet".

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -622,12 +622,16 @@ class EventProcessor:
             # bei QoS 0 Erfolg, waehrend die Nachricht verfaellt — und die Zeile behauptete
             # dann eine Meldung, die nie ankam. Eine echte Zustellbestaetigung gaebe es nur
             # mit QoS 1 und wait_for_publish(), das den Erkennungspfad blockieren wuerde.
-            info = self.client.publish(f"{self.prefix}/event",
-                                       json.dumps(payload, ensure_ascii=False))
-            if (getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS
-                    and self.client.is_connected()):
-                announced.add(name)
-                sent = True
+            # Verbindung VOR dem Senden pruefen, nicht danach: reisst sie im selben
+            # Moment ab, gaelte eine tatsaechlich abgeschickte Meldung als ungesendet —
+            # und der naechste Treffer wuerde sie erneut verschicken. Eine doppelte
+            # Benachrichtigung ist schlimmer als eine Zeile ohne Marke.
+            if self.client.is_connected():
+                info = self.client.publish(f"{self.prefix}/event",
+                                           json.dumps(payload, ensure_ascii=False))
+                if getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS:
+                    announced.add(name)
+                    sent = True
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -636,22 +636,28 @@ class EventProcessor:
         # Zeilen bei 200 Plaetzen, also 13 % weniger Reichweite. Der spaetere Ausschnitt
         # ist aber oft der bessere Beleg, deshalb ersetzt er das Bild, statt verworfen zu
         # werden.
-        if self.history is not None and crop is not None:
-            # Die vorhandene Zeile ist die Merkliste: gibt es noch keine — auch weil der
-            # erste Treffer ohne Ausschnitt kam oder das Anlegen scheiterte —, wird
+        # Nur was gemeldet wurde, gehoert in den Verlauf — er ist mit "was FaceID
+        # gemeldet hat" ueberschrieben. Ging die Meldung nicht hinaus (Broker weg), waere
+        # eine Zeile mit deren Score und Zeit eine Behauptung ueber etwas, das nie
+        # stattfand; die spaetere, tatsaechlich gemeldete Erkennung legt dann an.
+        if self.history is not None and crop is not None and name in announced:
+            # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
+            # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus
-            # dem Verlauf, obwohl sie stattgefunden hat.
+            # dem Verlauf, obwohl sie gemeldet wurde.
             hids = st.setdefault("hids", {})
             hid = hids.get(name)
+            if hid is not None:
+                if self.history.improve(hid, crop, emb, score,
+                                        attempt=st.get("attempts")) is None:
+                    hids.pop(name, None)
+                    hid = None
             if hid is None:
                 hid = self.history.add(
                     crop, emb, {k: v for k, v in payload.items() if k != "ts"}
                     | {"ts": payload["ts"], "attempt": st.get("attempts")})
                 if hid:
                     hids[name] = hid
-            else:
-                self.history.improve(hid, crop, emb, score,
-                                     attempt=st.get("attempts"))
 
     def _publish_presence(self, cam: str, last: dict | None = None):
         """Sensor-State = alle im Fenster gesehenen Personen ('Christian, Juli' / 'niemand')."""

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -640,14 +640,15 @@ class EventProcessor:
         # gemeldet hat" ueberschrieben. Ging die Meldung nicht hinaus (Broker weg), waere
         # eine Zeile mit deren Score und Zeit eine Behauptung ueber etwas, das nie
         # stattfand; die spaetere, tatsaechlich gemeldete Erkennung legt dann an.
-        # "Kein Client konfiguriert" ist etwas anderes als "Meldung fehlgeschlagen": ohne
-        # Broker kann nie etwas hinausgehen, und die Oberflaeche waere der einzige Ort,
-        # an dem die Erkennung ueberhaupt noch auftaucht — samt der Ausschnitte, auf denen
-        # die Fehleranalyse beruht. Dann wird aufgezeichnet. Steht ein Client bereit und
-        # die Meldung scheiterte nur, legt die spaetere, erfolgreiche Meldung die Zeile an.
-        reportable = self.client is not None
-        if (self.history is not None and crop is not None
-                and (name in announced or not reportable)):
+        # Aufgezeichnet wird JEDE Erkennung, auch eine, die gerade nicht hinausging —
+        # sonst gingen mit einem toten Broker genau die Ausschnitte verloren, auf denen
+        # die Fehleranalyse beruht. Ob gemeldet wurde, steht in der Zeile selbst, und die
+        # erste tatsaechlich gemeldete Erkennung uebernimmt dort Wert und Zeitpunkt: so
+        # behauptet der Verlauf nie eine Meldung, die es nicht gab, und verliert doch
+        # nichts. (Frueher entschied das ein Gate hier — das warf im Broker-Ausfall die
+        # ganze Erkennung weg.)
+        if self.history is not None and crop is not None:
+            published = name in announced
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus
@@ -655,15 +656,17 @@ class EventProcessor:
             hids = st.setdefault("hids", {})
             hid = hids.get(name)
             if hid is not None:
-                if self.history.improve(hid, crop, emb, score,
-                                        attempt=st.get("attempts")) is None:
+                if self.history.improve(hid, crop, emb, score, ts=payload["ts"],
+                                        attempt=st.get("attempts"),
+                                        reported=published) is None:
                     hids.pop(name, None)
                     hid = None
             if hid is None:
                 hid = self.history.add(
                     crop, emb, {k: v for k, v in payload.items() if k != "ts"}
-                    | {"ts": payload["ts"], "attempt": st.get("attempts")})
-                if hid:
+                    | {"ts": payload["ts"], "attempt": st.get("attempts"),
+                       "reported": published})
+                if hid is not None:
                     hids[name] = hid
 
     def _publish_presence(self, cam: str, last: dict | None = None):

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -629,7 +629,9 @@ class EventProcessor:
             if self.client.is_connected():
                 info = self.client.publish(f"{self.prefix}/event",
                                            json.dumps(payload, ensure_ascii=False))
-                if getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS:
+                # Kein rc am Ergebnis: als Fehlschlag werten. Ein fehlendes Feld ist
+                # keine Zusage, und die Marke soll im Zweifel zu wenig behaupten.
+                if getattr(info, "rc", None) == mqtt.MQTT_ERR_SUCCESS:
                     announced.add(name)
                     sent = True
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
@@ -678,7 +680,11 @@ class EventProcessor:
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus
             # dem Verlauf, obwohl sie gemeldet wurde.
             hids = st.setdefault("hids", {})
-            hid = hids.get(name)
+            # "unknown" ist kein Name, sondern das Fehlen eines Namens: im Vollbild
+            # koennen mehrere Fremde stehen, die alle so heissen. Sie zu einer Zeile
+            # zusammenzufassen wuerde ihre Gesichter gegeneinander austauschen — jede
+            # unbekannte Erkennung behaelt deshalb ihre eigene Zeile.
+            hid = hids.get(name) if name != "unknown" else None
             if hid is not None:
                 if self.history.improve(hid, crop, emb, score, ts=payload["ts"],
                                         attempt=st.get("attempts"),
@@ -690,7 +696,7 @@ class EventProcessor:
                     crop, emb, {k: v for k, v in payload.items() if k != "ts"}
                     | {"ts": payload["ts"], "attempt": st.get("attempts"),
                        "reported": published})
-                if hid is not None:
+                if hid is not None and name != "unknown":
                     hids[name] = hid
 
     def _publish_presence(self, cam: str, last: dict | None = None):

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -692,14 +692,15 @@ class EventProcessor:
             # (s. unten) — dort gilt deshalb nur, ob GENAU DIESE Meldung hinausging;
             # gemeldet wird ohnehin nur die erste, alle weiteren sperrt ``announced``.
             published = sent if name == "unknown" else name in announced
-            # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Meldet ausgerechnet
-            # ein Treffer OHNE Ausschnitt als erster, laeuft dieser Block gar nicht, und
-            # die Marke bleibt bis zum naechsten Treffer mit Bild auf "nicht gemeldet".
-            # Ebenso traegt eine Zeile, die nach einer Verdraengung neu entsteht, den Wert
-            # der ausloesenden statt der gemeldeten Erkennung. Beides betrifft nur die
-            # Marke und den angezeigten Wert, nie Meldung, Erkennung oder Ausschnitt — und
-            # der Weg dorthin (Verdraengung mitten im Ereignis bei 200 Plaetzen) waere mit
-            # mehr Zustand teurer erkauft als die Ungenauigkeit kostet.
+            # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Eine Zeile, die nach
+            # einer Verdraengung neu entsteht, traegt den Wert der ausloesenden statt der
+            # gemeldeten Erkennung. Bei Unbekannten kommt hinzu, dass die Marke am
+            # einzelnen Treffer haengt — meldet ausgerechnet einer ohne Ausschnitt, bleibt
+            # die spaeter entstehende Zeile auf "nicht gemeldet". Beides betrifft nur die
+            # Marke und den angezeigten Wert, nie Meldung, Erkennung oder Ausschnitt, und
+            # waere nur mit mehr Zustand je Ereignis zu haben, als es kostet.
+            # (Fuer benannte Personen greift der Fall nicht: dort zaehlt announced, das
+            # unabhaengig vom Ausschnitt gesetzt wird.)
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -615,11 +615,19 @@ class EventProcessor:
         # kein spaeterer Treffer koennte die Meldung nachholen. Der Verlauf fuehrt seine
         # eigene Merkliste (hids, s. unten).
         announced = st.setdefault("announced", set())
-        if self.client and name not in announced:
+        sent = False
+        if self.client is not None and name not in announced:
+            # is_connected() zusaetzlich zum rc: MQTT_ERR_SUCCESS heisst nur "in den
+            # Ausgangspuffer aufgenommen". Auf einer halb offenen Verbindung meldet paho
+            # bei QoS 0 Erfolg, waehrend die Nachricht verfaellt — und die Zeile behauptete
+            # dann eine Meldung, die nie ankam. Eine echte Zustellbestaetigung gaebe es nur
+            # mit QoS 1 und wait_for_publish(), das den Erkennungspfad blockieren wuerde.
             info = self.client.publish(f"{self.prefix}/event",
                                        json.dumps(payload, ensure_ascii=False))
-            if getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS:
+            if (getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS
+                    and self.client.is_connected()):
                 announced.add(name)
+                sent = True
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist
@@ -648,7 +656,10 @@ class EventProcessor:
         # nichts. (Frueher entschied das ein Gate hier — das warf im Broker-Ausfall die
         # ganze Erkennung weg.)
         if self.history is not None and crop is not None:
-            published = name in announced
+            # ``sent`` und nicht "die Person steht in announced": letzteres ist auch fuer
+            # jeden spaeteren Treffer wahr, der selbst nichts mehr meldet. Die Marke in der
+            # Zeile beantwortet genau eine Frage — ging DIESE Erkennung hinaus?
+            published = sent
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -665,6 +665,14 @@ class EventProcessor:
             # der erste, tatsaechlich gemeldete Treffer keinen Ausschnitt, entsteht die
             # Zeile erst spaeter und truege faelschlich "nicht gemeldet".
             published = sent or name in announced
+            # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Meldet ausgerechnet
+            # ein Treffer OHNE Ausschnitt als erster, laeuft dieser Block gar nicht, und
+            # die Marke bleibt bis zum naechsten Treffer mit Bild auf "nicht gemeldet".
+            # Ebenso traegt eine Zeile, die nach einer Verdraengung neu entsteht, den Wert
+            # der ausloesenden statt der gemeldeten Erkennung. Beides betrifft nur die
+            # Marke und den angezeigten Wert, nie Meldung, Erkennung oder Ausschnitt — und
+            # der Weg dorthin (Verdraengung mitten im Ereignis bei 200 Plaetzen) waere mit
+            # mehr Zustand teurer erkauft als die Ungenauigkeit kostet.
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -677,7 +677,7 @@ class EventProcessor:
             # die Ereignis-Ebene. Unbekannte behalten je Erkennung eine eigene Zeile
             # (s. unten) — dort gilt deshalb nur, ob GENAU DIESE Meldung hinausging;
             # gemeldet wird ohnehin nur die erste, alle weiteren sperrt ``announced``.
-            published = sent if name == "unknown" else (sent or name in announced)
+            published = sent if name == "unknown" else name in announced
             # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Meldet ausgerechnet
             # ein Treffer OHNE Ausschnitt als erster, laeuft dieser Block gar nicht, und
             # die Marke bleibt bis zum naechsten Treffer mit Bild auf "nicht gemeldet".

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -627,8 +627,15 @@ class EventProcessor:
             # und der naechste Treffer wuerde sie erneut verschicken. Eine doppelte
             # Benachrichtigung ist schlimmer als eine Zeile ohne Marke.
             if self.client.is_connected():
-                info = self.client.publish(f"{self.prefix}/event",
-                                           json.dumps(payload, ensure_ascii=False))
+                try:
+                    info = self.client.publish(f"{self.prefix}/event",
+                                               json.dumps(payload, ensure_ascii=False))
+                except Exception:
+                    # paho wirft durchaus (etwa ValueError bei zu grosser Nachricht).
+                    # Ungefangen risse das die ganze Erkennung mit — Sensor, Verlauf und
+                    # sub_label eingeschlossen —, obwohl nur die Meldung misslang.
+                    log.exception("could not publish the recognition for %s", name)
+                    info = None
                 # Kein rc am Ergebnis: als Fehlschlag werten. Ein fehlendes Feld ist
                 # keine Zusage, und die Marke soll im Zweifel zu wenig behaupten.
                 if getattr(info, "rc", None) == mqtt.MQTT_ERR_SUCCESS:

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -640,7 +640,14 @@ class EventProcessor:
         # gemeldet hat" ueberschrieben. Ging die Meldung nicht hinaus (Broker weg), waere
         # eine Zeile mit deren Score und Zeit eine Behauptung ueber etwas, das nie
         # stattfand; die spaetere, tatsaechlich gemeldete Erkennung legt dann an.
-        if self.history is not None and crop is not None and name in announced:
+        # "Kein Client konfiguriert" ist etwas anderes als "Meldung fehlgeschlagen": ohne
+        # Broker kann nie etwas hinausgehen, und die Oberflaeche waere der einzige Ort,
+        # an dem die Erkennung ueberhaupt noch auftaucht — samt der Ausschnitte, auf denen
+        # die Fehleranalyse beruht. Dann wird aufgezeichnet. Steht ein Client bereit und
+        # die Meldung scheiterte nur, legt die spaetere, erfolgreiche Meldung die Zeile an.
+        reportable = self.client is not None
+        if (self.history is not None and crop is not None
+                and (name in announced or not reportable)):
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -608,15 +608,18 @@ class EventProcessor:
         # Eine MENGE, kein einzelner Name: in einem Vollbild koennen mehrere Bekannte
         # stehen, die sich sonst gegenseitig ueberschreiben und abwechselnd neu gemeldet
         # wuerden — genau die Doppelmeldung, die diese Stelle verhindern soll.
-        # Nur vermerken, was wirklich hinausging: waere der Name schon beim fehlenden
-        # Client als gemeldet markiert, bliebe er es fuer dieses Ereignis auch nach dem
-        # Wiederverbinden — ein spaeterer Treffer koennte die Meldung nicht mehr
-        # nachholen. Der Verlauf fuehrt seine eigene Merkliste (hids, s. unten).
+        # Erst vermerken, wenn die Meldung den Client wirklich verlassen hat. Ein
+        # vorhandener Client heisst nicht, dass die Verbindung steht: bei getrenntem
+        # Broker liefert paho MQTT_ERR_NO_CONN. Wuerde der Name schon davor als gemeldet
+        # gelten, bliebe er es fuer dieses Ereignis auch nach dem Wiederverbinden, und
+        # kein spaeterer Treffer koennte die Meldung nachholen. Der Verlauf fuehrt seine
+        # eigene Merkliste (hids, s. unten).
         announced = st.setdefault("announced", set())
         if self.client and name not in announced:
-            announced.add(name)
-            self.client.publish(f"{self.prefix}/event",
-                                json.dumps(payload, ensure_ascii=False))
+            info = self.client.publish(f"{self.prefix}/event",
+                                       json.dumps(payload, ensure_ascii=False))
+            if getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS:
+                announced.add(name)
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist

--- a/app/mqtt_listener.py
+++ b/app/mqtt_listener.py
@@ -650,11 +650,17 @@ class EventProcessor:
                 # feststeht, dass NICHTS eingereiht wurde, darf ein spaeterer Treffer es
                 # erneut senden.
                 #
-                # ``sent`` markiert die Verlaufszeile und verlangt echten Erfolg: dort
-                # soll im Zweifel zu wenig behauptet werden, nicht zu viel.
+                # ``sent`` (und die daraus gefuellte Liste ``reported_names``) markiert
+                # die Verlaufszeile und verlangt echten Erfolg: dort soll im Zweifel zu
+                # wenig behauptet werden, nicht zu viel.
                 if rc not in (mqtt.MQTT_ERR_NO_CONN, mqtt.MQTT_ERR_QUEUE_SIZE):
                     announced.add(name)
                 sent = rc == mqtt.MQTT_ERR_SUCCESS
+                if sent:
+                    # Eigene Merkliste, weil ``announced`` bewusst lockerer ist: dort
+                    # steht der Name auch bei bloss eingereiht (MQTT_ERR_AGAIN) oder bei
+                    # unerwartetem Rueckgabewert. Fuer die Verlaufsmarke reicht das nicht.
+                    st.setdefault("reported_names", set()).add(name)
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist
@@ -665,46 +671,38 @@ class EventProcessor:
         # Den TATSAECHLICH benutzten Ausschnitt festhalten. Der Frigate-Snapshot wird
         # waehrend des Ereignisses fortlaufend ersetzt und zeigt spaeter oft einen anderen
         # Moment — eine Nachpruefung an ihm fuehrt in die Irre. Siehe app/history.py.
-        # EINE Zeile je (Ereignis, Person). Ein spaeterer Treffer derselben Person meldet
-        # nichts mehr (s. oben) — eine zweite Zeile behauptete also eine Meldung, die es
-        # nie gab, und verdraengte dabei aeltere echte Eintraege: gemessen 27 solcher
-        # Zeilen bei 200 Plaetzen, also 13 % weniger Reichweite. Der spaetere Ausschnitt
-        # ist aber oft der bessere Beleg, deshalb ersetzt er das Bild, statt verworfen zu
-        # werden.
-        # Nur was gemeldet wurde, gehoert in den Verlauf — er ist mit "was FaceID
-        # gemeldet hat" ueberschrieben. Ging die Meldung nicht hinaus (Broker weg), waere
-        # eine Zeile mit deren Score und Zeit eine Behauptung ueber etwas, das nie
-        # stattfand; die spaetere, tatsaechlich gemeldete Erkennung legt dann an.
-        # Aufgezeichnet wird JEDE Erkennung, auch eine, die gerade nicht hinausging —
-        # sonst gingen mit einem toten Broker genau die Ausschnitte verloren, auf denen
-        # die Fehleranalyse beruht. Ob gemeldet wurde, steht in der Zeile selbst, und die
-        # erste tatsaechlich gemeldete Erkennung uebernimmt dort Wert und Zeitpunkt: so
-        # behauptet der Verlauf nie eine Meldung, die es nicht gab, und verliert doch
-        # nichts. (Frueher entschied das ein Gate hier — das warf im Broker-Ausfall die
-        # ganze Erkennung weg.)
+        # Verlauf: EINE Zeile je (Ereignis, benannter Person).
+        #
+        # Frueher legte jeder Treffer eine Zeile an. Gemeldet wird aber nur der erste je
+        # Person (``announced`` sperrt die weiteren), also behaupteten die uebrigen eine
+        # Benachrichtigung, die es nie gab — und verdraengten dabei aeltere echte
+        # Eintraege: gemessen 27 solcher Zeilen bei 200 Plaetzen, 13 % weniger Reichweite.
+        # Der spaetere Ausschnitt ist aber oft der bessere Beleg, deshalb ersetzt er das
+        # Bild der bestehenden Zeile, statt verworfen zu werden.
+        #
+        # Aufgezeichnet wird JEDE Erkennung, auch eine, die nicht hinausging: sonst
+        # gingen bei totem Broker genau die Ausschnitte verloren, auf denen die
+        # Fehleranalyse beruht. Ob gemeldet wurde, steht als Marke in der Zeile, und die
+        # erste tatsaechlich gemeldete Erkennung uebernimmt dort Wert und Zeitpunkt.
         if self.history is not None and crop is not None:
-            # Die Marke beantwortet die Frage auf Ereignis-Ebene: ging fuer diese Person
-            # in diesem Ereignis eine Meldung hinaus? ``sent`` allein reicht nicht — hatte
-            # der erste, tatsaechlich gemeldete Treffer keinen Ausschnitt, entsteht die
-            # Zeile erst spaeter und truege faelschlich "nicht gemeldet".
-            # Bei benannten Personen traegt EINE Zeile das ganze Ereignis, also zaehlt
-            # die Ereignis-Ebene. Unbekannte behalten je Erkennung eine eigene Zeile
-            # (s. unten) — dort gilt deshalb nur, ob GENAU DIESE Meldung hinausging;
-            # gemeldet wird ohnehin nur die erste, alle weiteren sperrt ``announced``.
-            published = sent if name == "unknown" else name in announced
-            # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Eine Zeile, die nach
-            # einer Verdraengung neu entsteht, traegt den Wert der ausloesenden statt der
-            # gemeldeten Erkennung. Bei Unbekannten kommt hinzu, dass die Marke am
-            # einzelnen Treffer haengt — meldet ausgerechnet einer ohne Ausschnitt, bleibt
-            # die spaeter entstehende Zeile auf "nicht gemeldet". Beides betrifft nur die
-            # Marke und den angezeigten Wert, nie Meldung, Erkennung oder Ausschnitt, und
-            # waere nur mit mehr Zustand je Ereignis zu haben, als es kostet.
-            # (Fuer benannte Personen greift der Fall nicht: dort zaehlt announced, das
-            # unabhaengig vom Ausschnitt gesetzt wird.)
-            # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
-            # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
-            # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus
-            # dem Verlauf, obwohl sie gemeldet wurde.
+            # Die Marke: bei benannten Personen traegt eine Zeile das ganze Ereignis, also
+            # zaehlt, ob dafuer irgendwann eine Meldung bestaetigt hinausging — sonst
+            # truege eine Zeile faelschlich "nicht gemeldet", wenn ausgerechnet der
+            # gemeldete Treffer keinen Ausschnitt hatte. Unbekannte behalten je Erkennung
+            # eine eigene Zeile (s. unten), dort zaehlt nur diese eine Meldung.
+            published = (sent if name == "unknown"
+                         else name in st.get("reported_names", ()))
+            # Bekannte Ungenauigkeit, bewusst so belassen: Eine Zeile, die nach einer
+            # Verdraengung neu entsteht, traegt den Wert der ausloesenden statt der
+            # gemeldeten Erkennung; und bei Unbekannten bleibt die Marke auf "nicht
+            # gemeldet", wenn der gemeldete Treffer keinen Ausschnitt hatte. Beides
+            # betrifft nur Marke und angezeigten Wert, nie Meldung, Erkennung oder
+            # Ausschnitt — und waere nur mit mehr Zustand je Ereignis zu haben, als es
+            # kostet.
+            #
+            # Gibt es noch keine Zeile — oder wurde sie vom Limit verdraengt, was improve
+            # mit None meldet —, wird angelegt statt verbessert. Sonst fiele die Erkennung
+            # stillschweigend aus dem Verlauf.
             hids = st.setdefault("hids", {})
             # "unknown" ist kein Name, sondern das Fehlen eines Namens: im Vollbild
             # koennen mehrere Fremde stehen, die alle so heissen. Sie zu einer Zeile

--- a/faceid-addon/CHANGELOG.md
+++ b/faceid-addon/CHANGELOG.md
@@ -5,7 +5,9 @@ update dialog; standalone users can watch GitHub releases.
 
 ## 0.22.2 — 2026-09-04
 
-- **The history shows one row per event and person again.** It is titled "What FaceID
+- **The history shows one row per event and named person again** (unknown faces keep one row
+  each — several strangers in a single frame all carry that label, and merging them would
+  swap their pictures against each other). It is titled "What FaceID
   reported", but only the *first* match per person and event is ever reported — the
   `announced` set suppresses the rest. Every further row therefore claimed a notification
   that never happened, and pushed genuine older entries out: 27 such rows out of 200 slots

--- a/faceid-addon/CHANGELOG.md
+++ b/faceid-addon/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to FaceID. The Home Assistant app shows this file in the
 update dialog; standalone users can watch GitHub releases.
 
+## 0.22.2 — 2026-09-04
+
+- **The history shows one row per event and person again.** It is titled "What FaceID
+  reported", but only the *first* match per person and event is ever reported — the
+  `announced` set suppresses the rest. Every further row therefore claimed a notification
+  that never happened, and pushed genuine older entries out: 27 such rows out of 200 slots
+  on the reference instance, so the history reached 13% less far back than it should.
+- **Later matches are not discarded, they improve the row.** Checking the stored crops
+  first showed why that matters: all ten sampled duplicate pairs held *different* pictures,
+  sometimes drastically so — 8 KB against 94 KB of the same person, a distant crop against
+  a close one. Those later pictures are exactly what makes a wrong recognition checkable.
+  So a later match now replaces the picture when its score is higher, instead of adding a
+  row, and the card shows "best view 0.687" beside the reported score.
+- Picture and embedding are always replaced together. Keeping them apart would let the
+  "was wrong" analysis run on a different face than the row displays.
+
 ## 0.22.1 — 2026-09-04
 
 - **`live_hires_fallback` now also covers the case its name promises: no snapshot at all.**

--- a/faceid-addon/CHANGELOG.md
+++ b/faceid-addon/CHANGELOG.md
@@ -14,8 +14,11 @@ update dialog; standalone users can watch GitHub releases.
   first showed why that matters: all ten sampled duplicate pairs held *different* pictures,
   sometimes drastically so — 8 KB against 94 KB of the same person, a distant crop against
   a close one. Those later pictures are exactly what makes a wrong recognition checkable.
-  So a later match now replaces the picture when its score is higher, instead of adding a
-  row, and the card shows "best view 0.687" beside the reported score.
+  So a later match now improves the existing row instead of adding one: it replaces the
+  picture when its score is higher, and the card shows "best view 0.687" beside the
+  reported score. Independently of that, the first match that is actually published takes
+  over the row's score and timestamp even when it scores *lower* — it is the one somebody
+  received, and the card is headed "What FaceID reported".
 - Picture and embedding are always replaced together. Keeping them apart would let the
   "was wrong" analysis run on a different face than the row displays.
 

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -32,7 +32,9 @@ class History:
         self.dir = data_dir / "history"
         self.dir.mkdir(parents=True, exist_ok=True)
         self.keep = int(keep)
-        self._lock = threading.Lock()
+        # RLock, nicht Lock: delete() nimmt die Sperre selbst, und ein Aufrufer, der sie
+        # schon haelt, wuerde sich sonst selbst blockieren.
+        self._lock = threading.RLock()
 
     # ---------- Schreiben ----------
 
@@ -188,6 +190,9 @@ class History:
                     n += 1
                 new_img = f"{hid}.v{n}.jpg"
                 if not self._write_image(new_img, crop_bgr):
+                    # Ein halb geschriebenes Bild wuerde bis zum naechsten Aufraeumen
+                    # als Waise herumliegen.
+                    (self.dir / new_img).unlink(missing_ok=True)
                     return False
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
                 payload["best_score"] = round(float(score), 3)
@@ -250,6 +255,9 @@ class History:
             if not (self.dir / self._img_name(m, jf.stem)).exists():
                 continue
             item = {"id": jf.stem, **{k: v for k, v in m.items() if k != "embedding"}}
+            # Den geprueften Namen auch ausliefern: sonst pruefte die Zeile oben den
+            # bereinigten Wert, waehrend die Oberflaeche den rohen aus der Datei bekaeme.
+            item["img"] = self._img_name(m, jf.stem)
             if gallery is not None and m.get("embedding"):
                 try:
                     emb = np.array(m["embedding"], dtype=np.float32)

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -36,50 +36,38 @@ class History:
 
     # ---------- Schreiben ----------
 
-    def _write_pair(self, hid: str, crop_bgr, payload: dict) -> bool:
-        """Bild und JSON als Paar schreiben — beide oder keins.
+    def _img_name(self, payload: dict, hid: str) -> str:
+        """Dateiname des Bildes einer Zeile. Aeltere Zeilen kennen das Feld nicht."""
+        return str(payload.get("img") or f"{hid}.jpg")
 
-        ``cv2.imwrite`` wirft bei einem Fehler nicht, es gibt ``False`` zurueck (volle
-        Platte, unbeschreibbarer Pfad). Wird das uebergangen, beschreibt die JSON danach
-        ein Gesicht, das im .jpg gar nicht steht — und genau darauf laeuft spaeter die
-        Fehleranalyse.
-
-        Beide Dateien gehen zuerst nach ``.tmp`` und werden dann per ``os.replace``
-        eingehaengt. Ein Absturz zwischen den beiden ``replace`` bleibt theoretisch
-        moeglich; das Fenster schrumpft damit aber von zwei Schreibvorgaengen auf zwei
-        Metadaten-Operationen.
-        """
-        jpg, js = self.dir / f"{hid}.jpg", self.dir / f"{hid}.json"
-        # Eigenes Unterverzeichnis, und die Zwischendatei behaelt .jpg: OpenCV waehlt das
-        # Format ueber die Endung und schreibt nach ".jpg.tmp" gar nichts. Im selben
-        # Verzeichnis wuerde sie ausserdem vom *.json-Glob mitgezaehlt und taeuchte
-        # kurzzeitig als halbe Zeile im Verlauf auf.
+    def _write_json(self, js: Path, payload: dict) -> bool:
+        """JSON atomar ersetzen — der einzige Moment, in dem eine Zeile umschaltet."""
         tmpdir = self.dir / ".tmp"
         tmpdir.mkdir(exist_ok=True)
-        tmp_jpg, tmp_js = tmpdir / f"{hid}.jpg", tmpdir / f"{hid}.json"
-
-        backup = tmpdir / f"{hid}.prev.jpg"
+        tmp = tmpdir / f"{js.stem}.json"
         try:
-            if not cv2.imwrite(str(tmp_jpg), crop_bgr, [cv2.IMWRITE_JPEG_QUALITY, 88]):
-                log.warning("could not write the history image for %s", hid)
-                return False
-            tmp_js.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
-            # Das Bild wandert zuerst. Scheitert danach die JSON, waere das Bild neu und
-            # die Beschreibung alt — genau der Widerspruch, den diese Funktion verhindern
-            # soll. Deshalb vorher eine Kopie, die in dem Fall zurueckgespielt wird.
-            if jpg.exists():
-                os.replace(jpg, backup)
-            os.replace(tmp_jpg, jpg)
-            try:
-                os.replace(tmp_js, js)
-            except OSError:
-                if backup.exists():
-                    os.replace(backup, jpg)
-                raise
+            tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            os.replace(tmp, js)
             return True
+        except OSError:
+            log.exception("could not write the history entry %s", js.stem)
+            return False
         finally:
-            for f in (tmp_jpg, tmp_js, backup):
-                f.unlink(missing_ok=True)
+            tmp.unlink(missing_ok=True)
+
+    def _write_image(self, name: str, crop_bgr) -> bool:
+        """Bild unter seinem endgueltigen Namen schreiben.
+
+        ``cv2.imwrite`` wirft bei einem Fehler nicht immer, es gibt auch ``False``
+        zurueck (volle Platte, unbeschreibbarer Pfad) — beides muss abgefangen werden,
+        sonst beschriebe die JSON danach ein Bild, das es nicht gibt.
+        """
+        try:
+            return bool(cv2.imwrite(str(self.dir / name), crop_bgr,
+                                    [cv2.IMWRITE_JPEG_QUALITY, 88]))
+        except cv2.error:
+            log.warning("could not encode the history image %s", name)
+            return False
 
     def add(self, crop_bgr, embedding, meta: dict) -> str | None:
         """Einen veroeffentlichten Treffer ablegen. Fehler hier duerfen die Erkennung
@@ -98,7 +86,14 @@ class History:
                     hid = f"{base}_{n}"
                 payload = dict(meta)
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
-                if not self._write_pair(hid, crop_bgr, payload):
+                payload["img"] = f"{hid}.jpg"
+                # Reihenfolge ist der ganze Trick: Erst das Bild, dann die JSON. Gelistet
+                # wird ueber *.json, die Zeile entsteht also genau in dem Moment, in dem
+                # die JSON da ist — und dann liegt das Bild schon bereit.
+                if not self._write_image(payload["img"], crop_bgr):
+                    return None
+                if not self._write_json(self.dir / f"{hid}.json", payload):
+                    (self.dir / payload["img"]).unlink(missing_ok=True)
                     return None
                 self._enforce_cap()
                 return hid
@@ -132,7 +127,13 @@ class History:
                 jf = self.dir / f"{hid}.json"
                 if not jf.exists():
                     return None
-                payload = json.loads(jf.read_text(encoding="utf-8"))
+                try:
+                    payload = json.loads(jf.read_text(encoding="utf-8"))
+                except (ValueError, OSError):
+                    # Unlesbare Zeile: wie eine fehlende behandeln, damit der Aufrufer
+                    # neu anlegt statt sie fuer den Rest des Ereignisses einzufrieren.
+                    log.warning("history entry %s is unreadable — will be replaced", hid)
+                    return None
                 # Ein unlesbarer gespeicherter Wert darf nicht dazu fuehren, dass jede
                 # weitere Verbesserung still unterbleibt — dann lieber ersetzen.
                 try:
@@ -142,14 +143,29 @@ class History:
                     best = 0.0
                 if round(float(score), 3) <= best:
                     return False
+                # Das neue Bild bekommt einen EIGENEN Namen, das alte bleibt liegen.
+                # Damit aendert sich die Zeile ausschliesslich beim Ersetzen der JSON —
+                # scheitert irgendetwas davor oder dabei, zeigt sie unveraendert auf ihr
+                # altes, stimmiges Bild. Ein Zurueckspielen von Sicherungskopien braucht
+                # es dafuer nicht.
+                old_img = self._img_name(payload, hid)
+                n = 1
+                while (self.dir / f"{hid}.v{n}.jpg").exists():
+                    n += 1
+                new_img = f"{hid}.v{n}.jpg"
+                if not self._write_image(new_img, crop_bgr):
+                    return False
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
                 payload["best_score"] = round(float(score), 3)
+                payload["img"] = new_img
                 if attempt is not None:
                     payload["best_attempt"] = attempt
-                # Scheitert das Bild, bleibt die alte Zeile unveraendert stehen — lieber
-                # der aeltere, stimmige Stand als eine Zeile, die auf ein anderes
-                # Gesicht zeigt.
-                return self._write_pair(hid, crop_bgr, payload)
+                if not self._write_json(jf, payload):
+                    (self.dir / new_img).unlink(missing_ok=True)
+                    return False
+                if old_img != new_img:
+                    (self.dir / old_img).unlink(missing_ok=True)
+                return True
         except Exception:
             log.exception("could not update history entry %s", hid)
             return False
@@ -159,7 +175,10 @@ class History:
         files = sorted(self.dir.glob("*.json"), reverse=True)
         for old in files[self.keep:]:
             old.unlink(missing_ok=True)
-            (self.dir / f"{old.stem}.jpg").unlink(missing_ok=True)
+            # Auch die spaeteren Fassungen: eine verbesserte Zeile heisst <id>.vN.jpg,
+            # und wer nur <id>.jpg loescht, laesst Bilder liegen, die *.json nie zaehlt.
+            for img in self.dir.glob(f"{old.stem}.*jpg"):
+                img.unlink(missing_ok=True)
 
     # ---------- Lesen ----------
 
@@ -178,7 +197,7 @@ class History:
                 m = json.loads(jf.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 continue
-            if not (self.dir / f"{jf.stem}.jpg").exists():
+            if not (self.dir / self._img_name(m, jf.stem)).exists():
                 continue
             item = {"id": jf.stem, **{k: v for k, v in m.items() if k != "embedding"}}
             if gallery is not None and m.get("embedding"):
@@ -272,7 +291,8 @@ class History:
 
     def delete(self, hid: str):
         (self.dir / f"{hid}.json").unlink(missing_ok=True)
-        (self.dir / f"{hid}.jpg").unlink(missing_ok=True)
+        for img in self.dir.glob(f"{hid}.*jpg"):
+            img.unlink(missing_ok=True)
 
     def clear(self) -> int:
         n = 0

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -45,15 +45,25 @@ class History:
         name = Path(str(payload.get("img") or "")).name
         return name or f"{hid}.jpg"
 
-    def _images_of(self, stem: str):
-        """Alle Bildfassungen einer Zeile: ``<id>.jpg`` und ``<id>.vN.jpg``.
+    @staticmethod
+    def _row_of(img: Path) -> str:
+        """Zu welcher Zeile gehoert dieses Bild? ``<id>.jpg`` oder ``<id>.vN.jpg``.
 
-        Bewusst ohne ``glob``: die Kennung stuende dort als Muster, und ein ``*`` oder
-        ``[`` darin traefe fremde Zeilen.
+        Die einzige Stelle, die den Namensaufbau kennt — vorher fragten Verdraengung
+        und Waisensuche dasselbe auf zwei Arten.
         """
-        for f in self.dir.iterdir():
-            if f.suffix == ".jpg" and (f.name == f"{stem}.jpg"
-                                       or f.name.startswith(f"{stem}.v")):
+        name = img.name[:-len(".jpg")]
+        head, sep, tail = name.rpartition(".v")
+        return head if sep and tail.isdigit() else name
+
+    def _images_of(self, stem: str):
+        """Alle Bildfassungen einer Zeile.
+
+        Bewusst ohne Muster aus der Kennung: die ist Nutzdatum, und ein ``*`` oder
+        ``[`` darin traefe als Glob fremde Zeilen.
+        """
+        for f in self.dir.glob("*.jpg"):
+            if self._row_of(f) == stem:
                 yield f
 
     def _write_json(self, js: Path, payload: dict) -> bool:
@@ -188,7 +198,13 @@ class History:
                     (self.dir / new_img).unlink(missing_ok=True)
                     return False
                 if old_img != new_img:
-                    (self.dir / old_img).unlink(missing_ok=True)
+                    # Nur noch Aufraeumen — die Zeile steht bereits richtig. Ein Fehler
+                    # hier darf nicht als Fehlschlag zurueckgemeldet werden; das Bild
+                    # holt spaetestens der naechste Durchlauf von _enforce_cap.
+                    try:
+                        (self.dir / old_img).unlink(missing_ok=True)
+                    except OSError:
+                        log.warning("could not remove the superseded image %s", old_img)
                 return True
         except Exception:
             log.exception("could not update history entry %s", hid)
@@ -196,20 +212,17 @@ class History:
 
     def _enforce_cap(self):
         """Aelteste ueber dem Limit entfernen (Aufrufer haelt das Lock)."""
-        files = sorted(self.dir.glob("*.json"), reverse=True)
-        for old in files[self.keep:]:
+        for old in sorted(self.dir.glob("*.json"), reverse=True)[self.keep:]:
             old.unlink(missing_ok=True)
-            # Auch die spaeteren Fassungen: eine verbesserte Zeile heisst <id>.vN.jpg,
-            # und wer nur <id>.jpg loescht, laesst Bilder liegen, die *.json nie zaehlt.
-            for img in self._images_of(old.stem):
-                img.unlink(missing_ok=True)
-        # Bilder ohne Zeile einsammeln. Gelistet wird ueber *.json, ein Bild ohne JSON
-        # wuerde also nie wieder gezaehlt und nie geloescht — es waere unsichtbarer
-        # Ballast. Gefahrlos, weil beide Schreibwege das Lock halten und ein Bild nur
-        # waehrenddessen kurz ohne seine Zeile existiert.
-        known = {img for j in self.dir.glob("*.json") for img in self._images_of(j.stem)}
+        # Danach EIN Durchlauf ueber die Bilder: das raeumt die eben verdraengten Zeilen
+        # mit weg und ebenso Bilder, die auf anderem Weg ihre Zeile verloren haben — die
+        # wuerden sonst nie wieder gezaehlt, weil ueber *.json gelistet wird.
+        # Vorher lief _images_of je Zeile einmal ueber das ganze Verzeichnis.
+        # Gefahrlos, weil beide Schreibwege das Lock halten und ein Bild nur innerhalb
+        # dieses Abschnitts kurz ohne seine Zeile existiert.
+        stems = {j.stem for j in self.dir.glob("*.json")}
         for img in self.dir.glob("*.jpg"):
-            if img not in known:
+            if self._row_of(img) not in stems:
                 img.unlink(missing_ok=True)
 
     # ---------- Lesen ----------
@@ -322,9 +335,13 @@ class History:
     # ---------- Aufraeumen ----------
 
     def delete(self, hid: str):
-        (self.dir / f"{hid}.json").unlink(missing_ok=True)
-        for img in self._images_of(hid):
-            img.unlink(missing_ok=True)
+        # Unter derselben Sperre wie die Schreibwege: sonst koennte zwischen dem
+        # Entfernen der Zeile und ihrer Bilder ein laufendes improve() ein neues Bild
+        # anlegen, das anschliessend niemandem mehr gehoert.
+        with self._lock:
+            (self.dir / f"{hid}.json").unlink(missing_ok=True)
+            for img in self._images_of(hid):
+                img.unlink(missing_ok=True)
 
     def clear(self) -> int:
         n = 0

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -63,7 +63,7 @@ class History:
         ``[`` darin traefe als Glob fremde Zeilen.
         """
         for f in self.dir.glob("*.jpg"):
-            if self._row_of(f) == stem:
+            if f.stem == stem or self._row_of(f) == stem:
                 yield f
 
     def _write_json(self, js: Path, payload: dict) -> bool:
@@ -222,7 +222,12 @@ class History:
         # dieses Abschnitts kurz ohne seine Zeile existiert.
         stems = {j.stem for j in self.dir.glob("*.json")}
         for img in self.dir.glob("*.jpg"):
-            if self._row_of(img) not in stems:
+            # Erst der volle Name: gaebe es je eine Kennung, die selbst auf ".v<Ziffern>"
+            # endet, wuerde _row_of sie einer fremden Zeile zuschlagen und ihr lebendes
+            # Bild loeschen. Die Kennungen entstehen zwar aus time.time() und koennen
+            # keinen Punkt enthalten — aber das hier ist ein Aufraeumpfad, und der darf
+            # sich auf keine Annahme stuetzen, die er selbst nicht prueft.
+            if img.stem not in stems and self._row_of(img) not in stems:
                 img.unlink(missing_ok=True)
 
     # ---------- Lesen ----------

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -58,17 +58,28 @@ class History:
         tmpdir.mkdir(exist_ok=True)
         tmp_jpg, tmp_js = tmpdir / f"{hid}.jpg", tmpdir / f"{hid}.json"
 
+        backup = tmpdir / f"{hid}.prev.jpg"
         try:
             if not cv2.imwrite(str(tmp_jpg), crop_bgr, [cv2.IMWRITE_JPEG_QUALITY, 88]):
                 log.warning("could not write the history image for %s", hid)
                 return False
             tmp_js.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            # Das Bild wandert zuerst. Scheitert danach die JSON, waere das Bild neu und
+            # die Beschreibung alt — genau der Widerspruch, den diese Funktion verhindern
+            # soll. Deshalb vorher eine Kopie, die in dem Fall zurueckgespielt wird.
+            if jpg.exists():
+                os.replace(jpg, backup)
             os.replace(tmp_jpg, jpg)
-            os.replace(tmp_js, js)
+            try:
+                os.replace(tmp_js, js)
+            except OSError:
+                if backup.exists():
+                    os.replace(backup, jpg)
+                raise
             return True
         finally:
-            tmp_jpg.unlink(missing_ok=True)
-            tmp_js.unlink(missing_ok=True)
+            for f in (tmp_jpg, tmp_js, backup):
+                f.unlink(missing_ok=True)
 
     def add(self, crop_bgr, embedding, meta: dict) -> str | None:
         """Einen veroeffentlichten Treffer ablegen. Fehler hier duerfen die Erkennung
@@ -109,6 +120,10 @@ class History:
         eigentliche Fehler: Die Analyse liefe sonst auf einem anderen Gesicht, als die
         Zeile zeigt. ``score``/``ts`` bleiben die der Meldung, damit der Verlauf weiter
         beantwortet, womit sie ausgeloest wurde.
+
+        Rueckgabe: ``True`` uebernommen, ``False`` nicht besser, ``None`` die Zeile gibt
+        es nicht mehr (vom Limit verdraengt) — dann muss der Aufrufer neu anlegen, sonst
+        faellt die Erkennung stillschweigend aus dem Verlauf.
         """
         if self.keep <= 0 or crop_bgr is None or embedding is None or not hid:
             return False
@@ -116,9 +131,16 @@ class History:
             with self._lock:
                 jf = self.dir / f"{hid}.json"
                 if not jf.exists():
-                    return False
+                    return None
                 payload = json.loads(jf.read_text(encoding="utf-8"))
-                if float(score) <= float(payload.get("best_score", payload.get("score", 0))):
+                # Ein unlesbarer gespeicherter Wert darf nicht dazu fuehren, dass jede
+                # weitere Verbesserung still unterbleibt — dann lieber ersetzen.
+                try:
+                    best = round(float(payload.get("best_score",
+                                                   payload.get("score", 0))), 3)
+                except (TypeError, ValueError):
+                    best = 0.0
+                if round(float(score), 3) <= best:
                     return False
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
                 payload["best_score"] = round(float(score), 3)

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -179,6 +179,14 @@ class History:
             # und wer nur <id>.jpg loescht, laesst Bilder liegen, die *.json nie zaehlt.
             for img in self.dir.glob(f"{old.stem}.*jpg"):
                 img.unlink(missing_ok=True)
+        # Bilder ohne Zeile einsammeln. Gelistet wird ueber *.json, ein Bild ohne JSON
+        # wuerde also nie wieder gezaehlt und nie geloescht — es waere unsichtbarer
+        # Ballast. Gefahrlos, weil beide Schreibwege das Lock halten und ein Bild nur
+        # waehrenddessen kurz ohne seine Zeile existiert.
+        stems = {p.stem for p in self.dir.glob("*.json")}
+        for img in self.dir.glob("*.jpg"):
+            if img.name.split(".", 1)[0] not in stems:
+                img.unlink(missing_ok=True)
 
     # ---------- Lesen ----------
 

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -37,8 +37,24 @@ class History:
     # ---------- Schreiben ----------
 
     def _img_name(self, payload: dict, hid: str) -> str:
-        """Dateiname des Bildes einer Zeile. Aeltere Zeilen kennen das Feld nicht."""
-        return str(payload.get("img") or f"{hid}.jpg")
+        """Dateiname des Bildes einer Zeile. Aeltere Zeilen kennen das Feld nicht.
+
+        Nur der Basisname wird uebernommen: der Wert stammt aus einer Datei, und ein
+        Pfad darin duerfte nie mit ``self.dir`` zusammengesetzt werden.
+        """
+        name = Path(str(payload.get("img") or "")).name
+        return name or f"{hid}.jpg"
+
+    def _images_of(self, stem: str):
+        """Alle Bildfassungen einer Zeile: ``<id>.jpg`` und ``<id>.vN.jpg``.
+
+        Bewusst ohne ``glob``: die Kennung stuende dort als Muster, und ein ``*`` oder
+        ``[`` darin traefe fremde Zeilen.
+        """
+        for f in self.dir.iterdir():
+            if f.suffix == ".jpg" and (f.name == f"{stem}.jpg"
+                                       or f.name.startswith(f"{stem}.v")):
+                yield f
 
     def _write_json(self, js: Path, payload: dict) -> bool:
         """JSON atomar ersetzen — der einzige Moment, in dem eine Zeile umschaltet."""
@@ -49,7 +65,9 @@ class History:
             tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
             os.replace(tmp, js)
             return True
-        except OSError:
+        except (OSError, TypeError, ValueError):
+            # json.dumps scheitert an nicht serialisierbaren Werten mit TypeError —
+            # faengt man nur OSError, reisst es die ganze Erkennung mit.
             log.exception("could not write the history entry %s", js.stem)
             return False
         finally:
@@ -101,7 +119,8 @@ class History:
             log.exception("could not record a recognition in the history")
             return None
 
-    def improve(self, hid: str, crop_bgr, embedding, score: float, attempt=None) -> bool:
+    def improve(self, hid: str, crop_bgr, embedding, score: float,
+                attempt=None) -> bool | None:
         """Einen spaeteren, besseren Treffer derselben Person im selben Ereignis
         einarbeiten — ohne eine zweite Zeile anzulegen.
 
@@ -116,9 +135,14 @@ class History:
         Zeile zeigt. ``score``/``ts`` bleiben die der Meldung, damit der Verlauf weiter
         beantwortet, womit sie ausgeloest wurde.
 
-        Rueckgabe: ``True`` uebernommen, ``False`` nicht besser, ``None`` die Zeile gibt
-        es nicht mehr (vom Limit verdraengt) — dann muss der Aufrufer neu anlegen, sonst
-        faellt die Erkennung stillschweigend aus dem Verlauf.
+        Rueckgabe: ``True`` uebernommen; ``False`` nicht uebernommen, die Zeile steht
+        unveraendert (nicht besser, oder das Schreiben schlug fehl); ``None`` die Zeile
+        gibt es nicht mehr oder sie ist unlesbar — dann muss der Aufrufer neu anlegen,
+        sonst faellt die Erkennung stillschweigend aus dem Verlauf.
+
+        Ein unerwarteter Fehler ergibt bewusst ``False`` und nicht ``None``: die Zeile
+        existiert ja noch, und ein Neuanlegen brauechte genau das Duplikat, das diese
+        Funktion vermeiden soll.
         """
         if self.keep <= 0 or crop_bgr is None or embedding is None or not hid:
             return False
@@ -177,15 +201,15 @@ class History:
             old.unlink(missing_ok=True)
             # Auch die spaeteren Fassungen: eine verbesserte Zeile heisst <id>.vN.jpg,
             # und wer nur <id>.jpg loescht, laesst Bilder liegen, die *.json nie zaehlt.
-            for img in self.dir.glob(f"{old.stem}.*jpg"):
+            for img in self._images_of(old.stem):
                 img.unlink(missing_ok=True)
         # Bilder ohne Zeile einsammeln. Gelistet wird ueber *.json, ein Bild ohne JSON
         # wuerde also nie wieder gezaehlt und nie geloescht — es waere unsichtbarer
         # Ballast. Gefahrlos, weil beide Schreibwege das Lock halten und ein Bild nur
         # waehrenddessen kurz ohne seine Zeile existiert.
-        stems = {p.stem for p in self.dir.glob("*.json")}
+        known = {img for j in self.dir.glob("*.json") for img in self._images_of(j.stem)}
         for img in self.dir.glob("*.jpg"):
-            if img.name.split(".", 1)[0] not in stems:
+            if img not in known:
                 img.unlink(missing_ok=True)
 
     # ---------- Lesen ----------
@@ -299,7 +323,7 @@ class History:
 
     def delete(self, hid: str):
         (self.dir / f"{hid}.json").unlink(missing_ok=True)
-        for img in self.dir.glob(f"{hid}.*jpg"):
+        for img in self._images_of(hid):
             img.unlink(missing_ok=True)
 
     def clear(self) -> int:

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -14,6 +14,7 @@ und was passiert waere, haette es dieses Foto nicht gegeben.
 """
 import json
 import logging
+import os
 import threading
 import time
 from pathlib import Path
@@ -35,6 +36,33 @@ class History:
 
     # ---------- Schreiben ----------
 
+    def _write_pair(self, hid: str, crop_bgr, payload: dict) -> bool:
+        """Bild und JSON als Paar schreiben — beide oder keins.
+
+        ``cv2.imwrite`` wirft bei einem Fehler nicht, es gibt ``False`` zurueck (volle
+        Platte, unbeschreibbarer Pfad). Wird das uebergangen, beschreibt die JSON danach
+        ein Gesicht, das im .jpg gar nicht steht — und genau darauf laeuft spaeter die
+        Fehleranalyse.
+
+        Beide Dateien gehen zuerst nach ``.tmp`` und werden dann per ``os.replace``
+        eingehaengt. Ein Absturz zwischen den beiden ``replace`` bleibt theoretisch
+        moeglich; das Fenster schrumpft damit aber von zwei Schreibvorgaengen auf zwei
+        Metadaten-Operationen.
+        """
+        jpg, js = self.dir / f"{hid}.jpg", self.dir / f"{hid}.json"
+        tmp_jpg, tmp_js = jpg.with_suffix(".jpg.tmp"), js.with_suffix(".json.tmp")
+        try:
+            if not cv2.imwrite(str(tmp_jpg), crop_bgr, [cv2.IMWRITE_JPEG_QUALITY, 88]):
+                log.warning("could not write the history image for %s", hid)
+                return False
+            tmp_js.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            os.replace(tmp_jpg, jpg)
+            os.replace(tmp_js, js)
+            return True
+        finally:
+            tmp_jpg.unlink(missing_ok=True)
+            tmp_js.unlink(missing_ok=True)
+
     def add(self, crop_bgr, embedding, meta: dict) -> str | None:
         """Einen veroeffentlichten Treffer ablegen. Fehler hier duerfen die Erkennung
         nie stoeren — im Zweifel wird nichts gespeichert und weitergearbeitet."""
@@ -50,11 +78,10 @@ class History:
                 while (self.dir / f"{hid}.json").exists():
                     n += 1
                     hid = f"{base}_{n}"
-                cv2.imwrite(str(self.dir / f"{hid}.jpg"), crop_bgr, [cv2.IMWRITE_JPEG_QUALITY, 88])
                 payload = dict(meta)
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
-                (self.dir / f"{hid}.json").write_text(
-                    json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+                if not self._write_pair(hid, crop_bgr, payload):
+                    return None
                 self._enforce_cap()
                 return hid
         except Exception:
@@ -86,14 +113,14 @@ class History:
                 payload = json.loads(jf.read_text(encoding="utf-8"))
                 if float(score) <= float(payload.get("best_score", payload.get("score", 0))):
                     return False
-                cv2.imwrite(str(self.dir / f"{hid}.jpg"), crop_bgr,
-                            [cv2.IMWRITE_JPEG_QUALITY, 88])
                 payload["embedding"] = [round(float(v), 6) for v in embedding]
                 payload["best_score"] = round(float(score), 3)
                 if attempt is not None:
                     payload["best_attempt"] = attempt
-                jf.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
-                return True
+                # Scheitert das Bild, bleibt die alte Zeile unveraendert stehen — lieber
+                # der aeltere, stimmige Stand als eine Zeile, die auf ein anderes
+                # Gesicht zeigt.
+                return self._write_pair(hid, crop_bgr, payload)
         except Exception:
             log.exception("could not update history entry %s", hid)
             return False

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -50,7 +50,14 @@ class History:
         Metadaten-Operationen.
         """
         jpg, js = self.dir / f"{hid}.jpg", self.dir / f"{hid}.json"
-        tmp_jpg, tmp_js = jpg.with_suffix(".jpg.tmp"), js.with_suffix(".json.tmp")
+        # Eigenes Unterverzeichnis, und die Zwischendatei behaelt .jpg: OpenCV waehlt das
+        # Format ueber die Endung und schreibt nach ".jpg.tmp" gar nichts. Im selben
+        # Verzeichnis wuerde sie ausserdem vom *.json-Glob mitgezaehlt und taeuchte
+        # kurzzeitig als halbe Zeile im Verlauf auf.
+        tmpdir = self.dir / ".tmp"
+        tmpdir.mkdir(exist_ok=True)
+        tmp_jpg, tmp_js = tmpdir / f"{hid}.jpg", tmpdir / f"{hid}.json"
+
         try:
             if not cv2.imwrite(str(tmp_jpg), crop_bgr, [cv2.IMWRITE_JPEG_QUALITY, 88]):
                 log.warning("could not write the history image for %s", hid)

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -132,7 +132,7 @@ class History:
             return None
 
     def improve(self, hid: str, crop_bgr, embedding, score: float,
-                attempt=None) -> bool | None:
+                attempt=None, ts=None, reported: bool = False) -> bool | None:
         """Einen spaeteren, besseren Treffer derselben Person im selben Ereignis
         einarbeiten — ohne eine zweite Zeile anzulegen.
 
@@ -155,9 +155,15 @@ class History:
         Ein unerwarteter Fehler ergibt bewusst ``False`` und nicht ``None``: die Zeile
         existiert ja noch, und ein Neuanlegen brauechte genau das Duplikat, das diese
         Funktion vermeiden soll.
+
+        ``reported`` uebergibt, ob DIESE Erkennung hinausging. Trug die Zeile bisher eine
+        Erkennung, die nie gemeldet wurde (Broker weg), uebernimmt die erste tatsaechlich
+        gemeldete deren ``score``/``ts`` — sonst behauptete eine mit "was FaceID gemeldet
+        hat" ueberschriebene Karte einen Wert, den nie jemand bekommen hat.
         """
         if self.keep <= 0 or crop_bgr is None or embedding is None or not hid:
             return False
+        new_img = None
         try:
             with self._lock:
                 jf = self.dir / f"{hid}.json"
@@ -177,7 +183,11 @@ class History:
                                                    payload.get("score", 0))), 3)
                 except (TypeError, ValueError):
                     best = 0.0
-                if round(float(score), 3) <= best:
+                # Die erste wirklich gemeldete Erkennung darf die Zeile auch dann
+                # uebernehmen, wenn ihr Wert niedriger ist: sie ist die, die zaehlt.
+                takeover = bool(reported) and not payload.get("reported")
+                better = round(float(score), 3) > best
+                if not better and not takeover:
                     return False
                 # Das neue Bild bekommt einen EIGENEN Namen, das alte bleibt liegen.
                 # Damit aendert sich die Zeile ausschliesslich beim Ersetzen der JSON —
@@ -185,24 +195,32 @@ class History:
                 # altes, stimmiges Bild. Ein Zurueckspielen von Sicherungskopien braucht
                 # es dafuer nicht.
                 old_img = self._img_name(payload, hid)
-                n = 1
-                while (self.dir / f"{hid}.v{n}.jpg").exists():
-                    n += 1
-                new_img = f"{hid}.v{n}.jpg"
-                if not self._write_image(new_img, crop_bgr):
-                    # Ein halb geschriebenes Bild wuerde bis zum naechsten Aufraeumen
-                    # als Waise herumliegen.
-                    (self.dir / new_img).unlink(missing_ok=True)
-                    return False
-                payload["embedding"] = [round(float(v), 6) for v in embedding]
-                payload["best_score"] = round(float(score), 3)
-                payload["img"] = new_img
-                if attempt is not None:
-                    payload["best_attempt"] = attempt
+                if better:
+                    n = 1
+                    while (self.dir / f"{hid}.v{n}.jpg").exists():
+                        n += 1
+                    new_img = f"{hid}.v{n}.jpg"
+                    if not self._write_image(new_img, crop_bgr):
+                        # Ein halb geschriebenes Bild wuerde bis zum naechsten
+                        # Aufraeumen als Waise herumliegen.
+                        (self.dir / new_img).unlink(missing_ok=True)
+                        return False
+                    payload["embedding"] = [round(float(v), 6) for v in embedding]
+                    payload["best_score"] = round(float(score), 3)
+                    payload["img"] = new_img
+                    if attempt is not None:
+                        payload["best_attempt"] = attempt
+                if takeover:
+                    payload["reported"] = True
+                    payload["score"] = round(float(score), 3)
+                    if ts is not None:
+                        payload["ts"] = ts
+                    if attempt is not None:
+                        payload["attempt"] = attempt
                 if not self._write_json(jf, payload):
                     (self.dir / new_img).unlink(missing_ok=True)
                     return False
-                if old_img != new_img:
+                if new_img and old_img != new_img:
                     # Nur noch Aufraeumen — die Zeile steht bereits richtig. Ein Fehler
                     # hier darf nicht als Fehlschlag zurueckgemeldet werden; das Bild
                     # holt spaetestens der naechste Durchlauf von _enforce_cap.
@@ -212,6 +230,10 @@ class History:
                         log.warning("could not remove the superseded image %s", old_img)
                 return True
         except Exception:
+            # Ein schon geschriebenes neues Bild wuerde sonst liegen bleiben: der
+            # Aufraeumlauf haelt es fuer gueltig, weil seine Zeile ja noch existiert.
+            if new_img:
+                (self.dir / new_img).unlink(missing_ok=True)
             log.exception("could not update history entry %s", hid)
             return False
 

--- a/faceid-addon/app/history.py
+++ b/faceid-addon/app/history.py
@@ -61,6 +61,43 @@ class History:
             log.exception("could not record a recognition in the history")
             return None
 
+    def improve(self, hid: str, crop_bgr, embedding, score: float, attempt=None) -> bool:
+        """Einen spaeteren, besseren Treffer derselben Person im selben Ereignis
+        einarbeiten — ohne eine zweite Zeile anzulegen.
+
+        Gemeldet wurde nur der erste Treffer (das ``announced``-Set unterdrueckt
+        weitere), eine zweite Zeile behauptete also eine Meldung, die es nie gab. Der
+        spaetere Ausschnitt ist aber haeufig der weit bessere Beleg — gemessen bis zu
+        94 KB gegen 8 KB derselben Person —, und genau der macht eine Fehlerkennung
+        nachpruefbar. Also: eine Zeile, aber mit dem besten Bild.
+
+        Bild UND Embedding werden zusammen ersetzt. Sie getrennt zu behandeln waere der
+        eigentliche Fehler: Die Analyse liefe sonst auf einem anderen Gesicht, als die
+        Zeile zeigt. ``score``/``ts`` bleiben die der Meldung, damit der Verlauf weiter
+        beantwortet, womit sie ausgeloest wurde.
+        """
+        if self.keep <= 0 or crop_bgr is None or embedding is None or not hid:
+            return False
+        try:
+            with self._lock:
+                jf = self.dir / f"{hid}.json"
+                if not jf.exists():
+                    return False
+                payload = json.loads(jf.read_text(encoding="utf-8"))
+                if float(score) <= float(payload.get("best_score", payload.get("score", 0))):
+                    return False
+                cv2.imwrite(str(self.dir / f"{hid}.jpg"), crop_bgr,
+                            [cv2.IMWRITE_JPEG_QUALITY, 88])
+                payload["embedding"] = [round(float(v), 6) for v in embedding]
+                payload["best_score"] = round(float(score), 3)
+                if attempt is not None:
+                    payload["best_attempt"] = attempt
+                jf.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+                return True
+        except Exception:
+            log.exception("could not update history entry %s", hid)
+            return False
+
     def _enforce_cap(self):
         """Aelteste ueber dem Limit entfernen (Aufrufer haelt das Lock)."""
         files = sorted(self.dir.glob("*.json"), reverse=True)

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -608,15 +608,15 @@ class EventProcessor:
         # Eine MENGE, kein einzelner Name: in einem Vollbild koennen mehrere Bekannte
         # stehen, die sich sonst gegenseitig ueberschreiben und abwechselnd neu gemeldet
         # wuerden — genau die Doppelmeldung, die diese Stelle verhindern soll.
+        # Nur vermerken, was wirklich hinausging: waere der Name schon beim fehlenden
+        # Client als gemeldet markiert, bliebe er es fuer dieses Ereignis auch nach dem
+        # Wiederverbinden — ein spaeterer Treffer koennte die Meldung nicht mehr
+        # nachholen. Der Verlauf fuehrt seine eigene Merkliste (hids, s. unten).
         announced = st.setdefault("announced", set())
-        first_time = name not in announced
-        if first_time:
-            # Die Merkliste unabhaengig vom MQTT-Client fuehren: sie steuert auch den
-            # Verlauf, und ohne Client waere dort sonst jeder Treffer eine neue Zeile.
+        if self.client and name not in announced:
             announced.add(name)
-            if self.client:
-                self.client.publish(f"{self.prefix}/event",
-                                    json.dumps(payload, ensure_ascii=False))
+            self.client.publish(f"{self.prefix}/event",
+                                json.dumps(payload, ensure_ascii=False))
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist
@@ -634,15 +634,20 @@ class EventProcessor:
         # ist aber oft der bessere Beleg, deshalb ersetzt er das Bild, statt verworfen zu
         # werden.
         if self.history is not None and crop is not None:
+            # Die vorhandene Zeile ist die Merkliste: gibt es noch keine — auch weil der
+            # erste Treffer ohne Ausschnitt kam oder das Anlegen scheiterte —, wird
+            # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus
+            # dem Verlauf, obwohl sie stattgefunden hat.
             hids = st.setdefault("hids", {})
-            if first_time:
+            hid = hids.get(name)
+            if hid is None:
                 hid = self.history.add(
                     crop, emb, {k: v for k, v in payload.items() if k != "ts"}
                     | {"ts": payload["ts"], "attempt": st.get("attempts")})
                 if hid:
                     hids[name] = hid
-            elif hids.get(name):
-                self.history.improve(hids[name], crop, emb, score,
+            else:
+                self.history.improve(hid, crop, emb, score,
                                      attempt=st.get("attempts"))
 
     def _publish_presence(self, cam: str, last: dict | None = None):

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -660,10 +660,11 @@ class EventProcessor:
         # nichts. (Frueher entschied das ein Gate hier — das warf im Broker-Ausfall die
         # ganze Erkennung weg.)
         if self.history is not None and crop is not None:
-            # ``sent`` und nicht "die Person steht in announced": letzteres ist auch fuer
-            # jeden spaeteren Treffer wahr, der selbst nichts mehr meldet. Die Marke in der
-            # Zeile beantwortet genau eine Frage — ging DIESE Erkennung hinaus?
-            published = sent
+            # Die Marke beantwortet die Frage auf Ereignis-Ebene: ging fuer diese Person
+            # in diesem Ereignis eine Meldung hinaus? ``sent`` allein reicht nicht — hatte
+            # der erste, tatsaechlich gemeldete Treffer keinen Ausschnitt, entsteht die
+            # Zeile erst spaeter und truege faelschlich "nicht gemeldet".
+            published = sent or name in announced
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -636,11 +636,20 @@ class EventProcessor:
                     # sub_label eingeschlossen —, obwohl nur die Meldung misslang.
                     log.exception("could not publish the recognition for %s", name)
                     info = None
-                # Kein rc am Ergebnis: als Fehlschlag werten. Ein fehlendes Feld ist
-                # keine Zusage, und die Marke soll im Zweifel zu wenig behaupten.
-                if getattr(info, "rc", None) == mqtt.MQTT_ERR_SUCCESS:
+                rc = getattr(info, "rc", None)
+                # Zwei verschiedene Fragen, deshalb zwei Merker:
+                #
+                # ``announced`` verhindert die Doppelmeldung. Eingereiht ist verschickt —
+                # bei MQTT_ERR_AGAIN (voller Socket-Puffer) liegt das Paket in der
+                # Warteschlange und geht ueber den Netzwerk-Thread hinaus. Nur wo
+                # feststeht, dass NICHTS eingereiht wurde, darf ein spaeterer Treffer es
+                # erneut senden.
+                #
+                # ``sent`` markiert die Verlaufszeile und verlangt echten Erfolg: dort
+                # soll im Zweifel zu wenig behauptet werden, nicht zu viel.
+                if rc not in (mqtt.MQTT_ERR_NO_CONN, mqtt.MQTT_ERR_QUEUE_SIZE):
                     announced.add(name)
-                    sent = True
+                sent = rc == mqtt.MQTT_ERR_SUCCESS
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -609,9 +609,14 @@ class EventProcessor:
         # stehen, die sich sonst gegenseitig ueberschreiben und abwechselnd neu gemeldet
         # wuerden — genau die Doppelmeldung, die diese Stelle verhindern soll.
         announced = st.setdefault("announced", set())
-        if self.client and name not in announced:
+        first_time = name not in announced
+        if first_time:
+            # Die Merkliste unabhaengig vom MQTT-Client fuehren: sie steuert auch den
+            # Verlauf, und ohne Client waere dort sonst jeder Treffer eine neue Zeile.
             announced.add(name)
-            self.client.publish(f"{self.prefix}/event", json.dumps(payload, ensure_ascii=False))
+            if self.client:
+                self.client.publish(f"{self.prefix}/event",
+                                    json.dumps(payload, ensure_ascii=False))
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist
@@ -622,9 +627,23 @@ class EventProcessor:
         # Den TATSAECHLICH benutzten Ausschnitt festhalten. Der Frigate-Snapshot wird
         # waehrend des Ereignisses fortlaufend ersetzt und zeigt spaeter oft einen anderen
         # Moment — eine Nachpruefung an ihm fuehrt in die Irre. Siehe app/history.py.
+        # EINE Zeile je (Ereignis, Person). Ein spaeterer Treffer derselben Person meldet
+        # nichts mehr (s. oben) — eine zweite Zeile behauptete also eine Meldung, die es
+        # nie gab, und verdraengte dabei aeltere echte Eintraege: gemessen 27 solcher
+        # Zeilen bei 200 Plaetzen, also 13 % weniger Reichweite. Der spaetere Ausschnitt
+        # ist aber oft der bessere Beleg, deshalb ersetzt er das Bild, statt verworfen zu
+        # werden.
         if self.history is not None and crop is not None:
-            self.history.add(crop, emb, {k: v for k, v in payload.items() if k != "ts"}
-                             | {"ts": payload["ts"], "attempt": st.get("attempts")})
+            hids = st.setdefault("hids", {})
+            if first_time:
+                hid = self.history.add(
+                    crop, emb, {k: v for k, v in payload.items() if k != "ts"}
+                    | {"ts": payload["ts"], "attempt": st.get("attempts")})
+                if hid:
+                    hids[name] = hid
+            elif hids.get(name):
+                self.history.improve(hids[name], crop, emb, score,
+                                     attempt=st.get("attempts"))
 
     def _publish_presence(self, cam: str, last: dict | None = None):
         """Sensor-State = alle im Fenster gesehenen Personen ('Christian, Juli' / 'niemand')."""

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -635,8 +635,13 @@ class EventProcessor:
                     # Ungefangen risse das die ganze Erkennung mit — Sensor, Verlauf und
                     # sub_label eingeschlossen —, obwohl nur die Meldung misslang.
                     log.exception("could not publish the recognition for %s", name)
-                    info = None
-                rc = getattr(info, "rc", None)
+                    # Wirft der Aufruf, wurde garantiert nichts eingereiht — also wie ein
+                    # fehlender Broker behandeln, damit ein spaeterer Treffer die Meldung
+                    # nachholen darf. Ein neutrales None waere hier falsch: es zaehlte
+                    # unten als "vielleicht verschickt" und sperrte die Wiederholung.
+                    info, rc = None, mqtt.MQTT_ERR_NO_CONN
+                else:
+                    rc = getattr(info, "rc", None)
                 # Zwei verschiedene Fragen, deshalb zwei Merker:
                 #
                 # ``announced`` verhindert die Doppelmeldung. Eingereiht ist verschickt —

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -666,7 +666,11 @@ class EventProcessor:
             # in diesem Ereignis eine Meldung hinaus? ``sent`` allein reicht nicht — hatte
             # der erste, tatsaechlich gemeldete Treffer keinen Ausschnitt, entsteht die
             # Zeile erst spaeter und truege faelschlich "nicht gemeldet".
-            published = sent or name in announced
+            # Bei benannten Personen traegt EINE Zeile das ganze Ereignis, also zaehlt
+            # die Ereignis-Ebene. Unbekannte behalten je Erkennung eine eigene Zeile
+            # (s. unten) — dort gilt deshalb nur, ob GENAU DIESE Meldung hinausging;
+            # gemeldet wird ohnehin nur die erste, alle weiteren sperrt ``announced``.
+            published = sent if name == "unknown" else (sent or name in announced)
             # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Meldet ausgerechnet
             # ein Treffer OHNE Ausschnitt als erster, laeuft dieser Block gar nicht, und
             # die Marke bleibt bis zum naechsten Treffer mit Bild auf "nicht gemeldet".

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -622,12 +622,16 @@ class EventProcessor:
             # bei QoS 0 Erfolg, waehrend die Nachricht verfaellt — und die Zeile behauptete
             # dann eine Meldung, die nie ankam. Eine echte Zustellbestaetigung gaebe es nur
             # mit QoS 1 und wait_for_publish(), das den Erkennungspfad blockieren wuerde.
-            info = self.client.publish(f"{self.prefix}/event",
-                                       json.dumps(payload, ensure_ascii=False))
-            if (getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS
-                    and self.client.is_connected()):
-                announced.add(name)
-                sent = True
+            # Verbindung VOR dem Senden pruefen, nicht danach: reisst sie im selben
+            # Moment ab, gaelte eine tatsaechlich abgeschickte Meldung als ungesendet —
+            # und der naechste Treffer wuerde sie erneut verschicken. Eine doppelte
+            # Benachrichtigung ist schlimmer als eine Zeile ohne Marke.
+            if self.client.is_connected():
+                info = self.client.publish(f"{self.prefix}/event",
+                                           json.dumps(payload, ensure_ascii=False))
+                if getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS:
+                    announced.add(name)
+                    sent = True
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -636,22 +636,28 @@ class EventProcessor:
         # Zeilen bei 200 Plaetzen, also 13 % weniger Reichweite. Der spaetere Ausschnitt
         # ist aber oft der bessere Beleg, deshalb ersetzt er das Bild, statt verworfen zu
         # werden.
-        if self.history is not None and crop is not None:
-            # Die vorhandene Zeile ist die Merkliste: gibt es noch keine — auch weil der
-            # erste Treffer ohne Ausschnitt kam oder das Anlegen scheiterte —, wird
+        # Nur was gemeldet wurde, gehoert in den Verlauf — er ist mit "was FaceID
+        # gemeldet hat" ueberschrieben. Ging die Meldung nicht hinaus (Broker weg), waere
+        # eine Zeile mit deren Score und Zeit eine Behauptung ueber etwas, das nie
+        # stattfand; die spaetere, tatsaechlich gemeldete Erkennung legt dann an.
+        if self.history is not None and crop is not None and name in announced:
+            # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
+            # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus
-            # dem Verlauf, obwohl sie stattgefunden hat.
+            # dem Verlauf, obwohl sie gemeldet wurde.
             hids = st.setdefault("hids", {})
             hid = hids.get(name)
+            if hid is not None:
+                if self.history.improve(hid, crop, emb, score,
+                                        attempt=st.get("attempts")) is None:
+                    hids.pop(name, None)
+                    hid = None
             if hid is None:
                 hid = self.history.add(
                     crop, emb, {k: v for k, v in payload.items() if k != "ts"}
                     | {"ts": payload["ts"], "attempt": st.get("attempts")})
                 if hid:
                     hids[name] = hid
-            else:
-                self.history.improve(hid, crop, emb, score,
-                                     attempt=st.get("attempts"))
 
     def _publish_presence(self, cam: str, last: dict | None = None):
         """Sensor-State = alle im Fenster gesehenen Personen ('Christian, Juli' / 'niemand')."""

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -640,14 +640,15 @@ class EventProcessor:
         # gemeldet hat" ueberschrieben. Ging die Meldung nicht hinaus (Broker weg), waere
         # eine Zeile mit deren Score und Zeit eine Behauptung ueber etwas, das nie
         # stattfand; die spaetere, tatsaechlich gemeldete Erkennung legt dann an.
-        # "Kein Client konfiguriert" ist etwas anderes als "Meldung fehlgeschlagen": ohne
-        # Broker kann nie etwas hinausgehen, und die Oberflaeche waere der einzige Ort,
-        # an dem die Erkennung ueberhaupt noch auftaucht — samt der Ausschnitte, auf denen
-        # die Fehleranalyse beruht. Dann wird aufgezeichnet. Steht ein Client bereit und
-        # die Meldung scheiterte nur, legt die spaetere, erfolgreiche Meldung die Zeile an.
-        reportable = self.client is not None
-        if (self.history is not None and crop is not None
-                and (name in announced or not reportable)):
+        # Aufgezeichnet wird JEDE Erkennung, auch eine, die gerade nicht hinausging —
+        # sonst gingen mit einem toten Broker genau die Ausschnitte verloren, auf denen
+        # die Fehleranalyse beruht. Ob gemeldet wurde, steht in der Zeile selbst, und die
+        # erste tatsaechlich gemeldete Erkennung uebernimmt dort Wert und Zeitpunkt: so
+        # behauptet der Verlauf nie eine Meldung, die es nicht gab, und verliert doch
+        # nichts. (Frueher entschied das ein Gate hier — das warf im Broker-Ausfall die
+        # ganze Erkennung weg.)
+        if self.history is not None and crop is not None:
+            published = name in announced
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus
@@ -655,15 +656,17 @@ class EventProcessor:
             hids = st.setdefault("hids", {})
             hid = hids.get(name)
             if hid is not None:
-                if self.history.improve(hid, crop, emb, score,
-                                        attempt=st.get("attempts")) is None:
+                if self.history.improve(hid, crop, emb, score, ts=payload["ts"],
+                                        attempt=st.get("attempts"),
+                                        reported=published) is None:
                     hids.pop(name, None)
                     hid = None
             if hid is None:
                 hid = self.history.add(
                     crop, emb, {k: v for k, v in payload.items() if k != "ts"}
-                    | {"ts": payload["ts"], "attempt": st.get("attempts")})
-                if hid:
+                    | {"ts": payload["ts"], "attempt": st.get("attempts"),
+                       "reported": published})
+                if hid is not None:
                     hids[name] = hid
 
     def _publish_presence(self, cam: str, last: dict | None = None):

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -629,7 +629,9 @@ class EventProcessor:
             if self.client.is_connected():
                 info = self.client.publish(f"{self.prefix}/event",
                                            json.dumps(payload, ensure_ascii=False))
-                if getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS:
+                # Kein rc am Ergebnis: als Fehlschlag werten. Ein fehlendes Feld ist
+                # keine Zusage, und die Marke soll im Zweifel zu wenig behaupten.
+                if getattr(info, "rc", None) == mqtt.MQTT_ERR_SUCCESS:
                     announced.add(name)
                     sent = True
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
@@ -678,7 +680,11 @@ class EventProcessor:
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus
             # dem Verlauf, obwohl sie gemeldet wurde.
             hids = st.setdefault("hids", {})
-            hid = hids.get(name)
+            # "unknown" ist kein Name, sondern das Fehlen eines Namens: im Vollbild
+            # koennen mehrere Fremde stehen, die alle so heissen. Sie zu einer Zeile
+            # zusammenzufassen wuerde ihre Gesichter gegeneinander austauschen — jede
+            # unbekannte Erkennung behaelt deshalb ihre eigene Zeile.
+            hid = hids.get(name) if name != "unknown" else None
             if hid is not None:
                 if self.history.improve(hid, crop, emb, score, ts=payload["ts"],
                                         attempt=st.get("attempts"),
@@ -690,7 +696,7 @@ class EventProcessor:
                     crop, emb, {k: v for k, v in payload.items() if k != "ts"}
                     | {"ts": payload["ts"], "attempt": st.get("attempts"),
                        "reported": published})
-                if hid is not None:
+                if hid is not None and name != "unknown":
                     hids[name] = hid
 
     def _publish_presence(self, cam: str, last: dict | None = None):

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -692,14 +692,15 @@ class EventProcessor:
             # (s. unten) — dort gilt deshalb nur, ob GENAU DIESE Meldung hinausging;
             # gemeldet wird ohnehin nur die erste, alle weiteren sperrt ``announced``.
             published = sent if name == "unknown" else name in announced
-            # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Meldet ausgerechnet
-            # ein Treffer OHNE Ausschnitt als erster, laeuft dieser Block gar nicht, und
-            # die Marke bleibt bis zum naechsten Treffer mit Bild auf "nicht gemeldet".
-            # Ebenso traegt eine Zeile, die nach einer Verdraengung neu entsteht, den Wert
-            # der ausloesenden statt der gemeldeten Erkennung. Beides betrifft nur die
-            # Marke und den angezeigten Wert, nie Meldung, Erkennung oder Ausschnitt — und
-            # der Weg dorthin (Verdraengung mitten im Ereignis bei 200 Plaetzen) waere mit
-            # mehr Zustand teurer erkauft als die Ungenauigkeit kostet.
+            # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Eine Zeile, die nach
+            # einer Verdraengung neu entsteht, traegt den Wert der ausloesenden statt der
+            # gemeldeten Erkennung. Bei Unbekannten kommt hinzu, dass die Marke am
+            # einzelnen Treffer haengt — meldet ausgerechnet einer ohne Ausschnitt, bleibt
+            # die spaeter entstehende Zeile auf "nicht gemeldet". Beides betrifft nur die
+            # Marke und den angezeigten Wert, nie Meldung, Erkennung oder Ausschnitt, und
+            # waere nur mit mehr Zustand je Ereignis zu haben, als es kostet.
+            # (Fuer benannte Personen greift der Fall nicht: dort zaehlt announced, das
+            # unabhaengig vom Ausschnitt gesetzt wird.)
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -615,11 +615,19 @@ class EventProcessor:
         # kein spaeterer Treffer koennte die Meldung nachholen. Der Verlauf fuehrt seine
         # eigene Merkliste (hids, s. unten).
         announced = st.setdefault("announced", set())
-        if self.client and name not in announced:
+        sent = False
+        if self.client is not None and name not in announced:
+            # is_connected() zusaetzlich zum rc: MQTT_ERR_SUCCESS heisst nur "in den
+            # Ausgangspuffer aufgenommen". Auf einer halb offenen Verbindung meldet paho
+            # bei QoS 0 Erfolg, waehrend die Nachricht verfaellt — und die Zeile behauptete
+            # dann eine Meldung, die nie ankam. Eine echte Zustellbestaetigung gaebe es nur
+            # mit QoS 1 und wait_for_publish(), das den Erkennungspfad blockieren wuerde.
             info = self.client.publish(f"{self.prefix}/event",
                                        json.dumps(payload, ensure_ascii=False))
-            if getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS:
+            if (getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS
+                    and self.client.is_connected()):
                 announced.add(name)
+                sent = True
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist
@@ -648,7 +656,10 @@ class EventProcessor:
         # nichts. (Frueher entschied das ein Gate hier — das warf im Broker-Ausfall die
         # ganze Erkennung weg.)
         if self.history is not None and crop is not None:
-            published = name in announced
+            # ``sent`` und nicht "die Person steht in announced": letzteres ist auch fuer
+            # jeden spaeteren Treffer wahr, der selbst nichts mehr meldet. Die Marke in der
+            # Zeile beantwortet genau eine Frage — ging DIESE Erkennung hinaus?
+            published = sent
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -665,6 +665,14 @@ class EventProcessor:
             # der erste, tatsaechlich gemeldete Treffer keinen Ausschnitt, entsteht die
             # Zeile erst spaeter und truege faelschlich "nicht gemeldet".
             published = sent or name in announced
+            # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Meldet ausgerechnet
+            # ein Treffer OHNE Ausschnitt als erster, laeuft dieser Block gar nicht, und
+            # die Marke bleibt bis zum naechsten Treffer mit Bild auf "nicht gemeldet".
+            # Ebenso traegt eine Zeile, die nach einer Verdraengung neu entsteht, den Wert
+            # der ausloesenden statt der gemeldeten Erkennung. Beides betrifft nur die
+            # Marke und den angezeigten Wert, nie Meldung, Erkennung oder Ausschnitt — und
+            # der Weg dorthin (Verdraengung mitten im Ereignis bei 200 Plaetzen) waere mit
+            # mehr Zustand teurer erkauft als die Ungenauigkeit kostet.
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -677,7 +677,7 @@ class EventProcessor:
             # die Ereignis-Ebene. Unbekannte behalten je Erkennung eine eigene Zeile
             # (s. unten) — dort gilt deshalb nur, ob GENAU DIESE Meldung hinausging;
             # gemeldet wird ohnehin nur die erste, alle weiteren sperrt ``announced``.
-            published = sent if name == "unknown" else (sent or name in announced)
+            published = sent if name == "unknown" else name in announced
             # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Meldet ausgerechnet
             # ein Treffer OHNE Ausschnitt als erster, laeuft dieser Block gar nicht, und
             # die Marke bleibt bis zum naechsten Treffer mit Bild auf "nicht gemeldet".

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -627,8 +627,15 @@ class EventProcessor:
             # und der naechste Treffer wuerde sie erneut verschicken. Eine doppelte
             # Benachrichtigung ist schlimmer als eine Zeile ohne Marke.
             if self.client.is_connected():
-                info = self.client.publish(f"{self.prefix}/event",
-                                           json.dumps(payload, ensure_ascii=False))
+                try:
+                    info = self.client.publish(f"{self.prefix}/event",
+                                               json.dumps(payload, ensure_ascii=False))
+                except Exception:
+                    # paho wirft durchaus (etwa ValueError bei zu grosser Nachricht).
+                    # Ungefangen risse das die ganze Erkennung mit — Sensor, Verlauf und
+                    # sub_label eingeschlossen —, obwohl nur die Meldung misslang.
+                    log.exception("could not publish the recognition for %s", name)
+                    info = None
                 # Kein rc am Ergebnis: als Fehlschlag werten. Ein fehlendes Feld ist
                 # keine Zusage, und die Marke soll im Zweifel zu wenig behaupten.
                 if getattr(info, "rc", None) == mqtt.MQTT_ERR_SUCCESS:

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -640,7 +640,14 @@ class EventProcessor:
         # gemeldet hat" ueberschrieben. Ging die Meldung nicht hinaus (Broker weg), waere
         # eine Zeile mit deren Score und Zeit eine Behauptung ueber etwas, das nie
         # stattfand; die spaetere, tatsaechlich gemeldete Erkennung legt dann an.
-        if self.history is not None and crop is not None and name in announced:
+        # "Kein Client konfiguriert" ist etwas anderes als "Meldung fehlgeschlagen": ohne
+        # Broker kann nie etwas hinausgehen, und die Oberflaeche waere der einzige Ort,
+        # an dem die Erkennung ueberhaupt noch auftaucht — samt der Ausschnitte, auf denen
+        # die Fehleranalyse beruht. Dann wird aufgezeichnet. Steht ein Client bereit und
+        # die Meldung scheiterte nur, legt die spaetere, erfolgreiche Meldung die Zeile an.
+        reportable = self.client is not None
+        if (self.history is not None and crop is not None
+                and (name in announced or not reportable)):
             # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
             # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
             # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -608,15 +608,18 @@ class EventProcessor:
         # Eine MENGE, kein einzelner Name: in einem Vollbild koennen mehrere Bekannte
         # stehen, die sich sonst gegenseitig ueberschreiben und abwechselnd neu gemeldet
         # wuerden — genau die Doppelmeldung, die diese Stelle verhindern soll.
-        # Nur vermerken, was wirklich hinausging: waere der Name schon beim fehlenden
-        # Client als gemeldet markiert, bliebe er es fuer dieses Ereignis auch nach dem
-        # Wiederverbinden — ein spaeterer Treffer koennte die Meldung nicht mehr
-        # nachholen. Der Verlauf fuehrt seine eigene Merkliste (hids, s. unten).
+        # Erst vermerken, wenn die Meldung den Client wirklich verlassen hat. Ein
+        # vorhandener Client heisst nicht, dass die Verbindung steht: bei getrenntem
+        # Broker liefert paho MQTT_ERR_NO_CONN. Wuerde der Name schon davor als gemeldet
+        # gelten, bliebe er es fuer dieses Ereignis auch nach dem Wiederverbinden, und
+        # kein spaeterer Treffer koennte die Meldung nachholen. Der Verlauf fuehrt seine
+        # eigene Merkliste (hids, s. unten).
         announced = st.setdefault("announced", set())
         if self.client and name not in announced:
-            announced.add(name)
-            self.client.publish(f"{self.prefix}/event",
-                                json.dumps(payload, ensure_ascii=False))
+            info = self.client.publish(f"{self.prefix}/event",
+                                       json.dumps(payload, ensure_ascii=False))
+            if getattr(info, "rc", mqtt.MQTT_ERR_SUCCESS) == mqtt.MQTT_ERR_SUCCESS:
+                announced.add(name)
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist

--- a/faceid-addon/app/mqtt_listener.py
+++ b/faceid-addon/app/mqtt_listener.py
@@ -650,11 +650,17 @@ class EventProcessor:
                 # feststeht, dass NICHTS eingereiht wurde, darf ein spaeterer Treffer es
                 # erneut senden.
                 #
-                # ``sent`` markiert die Verlaufszeile und verlangt echten Erfolg: dort
-                # soll im Zweifel zu wenig behauptet werden, nicht zu viel.
+                # ``sent`` (und die daraus gefuellte Liste ``reported_names``) markiert
+                # die Verlaufszeile und verlangt echten Erfolg: dort soll im Zweifel zu
+                # wenig behauptet werden, nicht zu viel.
                 if rc not in (mqtt.MQTT_ERR_NO_CONN, mqtt.MQTT_ERR_QUEUE_SIZE):
                     announced.add(name)
                 sent = rc == mqtt.MQTT_ERR_SUCCESS
+                if sent:
+                    # Eigene Merkliste, weil ``announced`` bewusst lockerer ist: dort
+                    # steht der Name auch bei bloss eingereiht (MQTT_ERR_AGAIN) oder bei
+                    # unerwartetem Rueckgabewert. Fuer die Verlaufsmarke reicht das nicht.
+                    st.setdefault("reported_names", set()).add(name)
         # "unknown" gehoert NICHT in die Anwesenheitsliste. Der Sensor-State ist eine
         # Aufzaehlung von Namen ("Christian, Juli"), und ein hineingemischtes "unknown"
         # liest sich wie ein weiterer Name — auf dem Handy stand "Christian unknown ist
@@ -665,46 +671,38 @@ class EventProcessor:
         # Den TATSAECHLICH benutzten Ausschnitt festhalten. Der Frigate-Snapshot wird
         # waehrend des Ereignisses fortlaufend ersetzt und zeigt spaeter oft einen anderen
         # Moment — eine Nachpruefung an ihm fuehrt in die Irre. Siehe app/history.py.
-        # EINE Zeile je (Ereignis, Person). Ein spaeterer Treffer derselben Person meldet
-        # nichts mehr (s. oben) — eine zweite Zeile behauptete also eine Meldung, die es
-        # nie gab, und verdraengte dabei aeltere echte Eintraege: gemessen 27 solcher
-        # Zeilen bei 200 Plaetzen, also 13 % weniger Reichweite. Der spaetere Ausschnitt
-        # ist aber oft der bessere Beleg, deshalb ersetzt er das Bild, statt verworfen zu
-        # werden.
-        # Nur was gemeldet wurde, gehoert in den Verlauf — er ist mit "was FaceID
-        # gemeldet hat" ueberschrieben. Ging die Meldung nicht hinaus (Broker weg), waere
-        # eine Zeile mit deren Score und Zeit eine Behauptung ueber etwas, das nie
-        # stattfand; die spaetere, tatsaechlich gemeldete Erkennung legt dann an.
-        # Aufgezeichnet wird JEDE Erkennung, auch eine, die gerade nicht hinausging —
-        # sonst gingen mit einem toten Broker genau die Ausschnitte verloren, auf denen
-        # die Fehleranalyse beruht. Ob gemeldet wurde, steht in der Zeile selbst, und die
-        # erste tatsaechlich gemeldete Erkennung uebernimmt dort Wert und Zeitpunkt: so
-        # behauptet der Verlauf nie eine Meldung, die es nicht gab, und verliert doch
-        # nichts. (Frueher entschied das ein Gate hier — das warf im Broker-Ausfall die
-        # ganze Erkennung weg.)
+        # Verlauf: EINE Zeile je (Ereignis, benannter Person).
+        #
+        # Frueher legte jeder Treffer eine Zeile an. Gemeldet wird aber nur der erste je
+        # Person (``announced`` sperrt die weiteren), also behaupteten die uebrigen eine
+        # Benachrichtigung, die es nie gab — und verdraengten dabei aeltere echte
+        # Eintraege: gemessen 27 solcher Zeilen bei 200 Plaetzen, 13 % weniger Reichweite.
+        # Der spaetere Ausschnitt ist aber oft der bessere Beleg, deshalb ersetzt er das
+        # Bild der bestehenden Zeile, statt verworfen zu werden.
+        #
+        # Aufgezeichnet wird JEDE Erkennung, auch eine, die nicht hinausging: sonst
+        # gingen bei totem Broker genau die Ausschnitte verloren, auf denen die
+        # Fehleranalyse beruht. Ob gemeldet wurde, steht als Marke in der Zeile, und die
+        # erste tatsaechlich gemeldete Erkennung uebernimmt dort Wert und Zeitpunkt.
         if self.history is not None and crop is not None:
-            # Die Marke beantwortet die Frage auf Ereignis-Ebene: ging fuer diese Person
-            # in diesem Ereignis eine Meldung hinaus? ``sent`` allein reicht nicht — hatte
-            # der erste, tatsaechlich gemeldete Treffer keinen Ausschnitt, entsteht die
-            # Zeile erst spaeter und truege faelschlich "nicht gemeldet".
-            # Bei benannten Personen traegt EINE Zeile das ganze Ereignis, also zaehlt
-            # die Ereignis-Ebene. Unbekannte behalten je Erkennung eine eigene Zeile
-            # (s. unten) — dort gilt deshalb nur, ob GENAU DIESE Meldung hinausging;
-            # gemeldet wird ohnehin nur die erste, alle weiteren sperrt ``announced``.
-            published = sent if name == "unknown" else name in announced
-            # Bekannte Ungenauigkeit, bewusst nicht weiter verfolgt: Eine Zeile, die nach
-            # einer Verdraengung neu entsteht, traegt den Wert der ausloesenden statt der
-            # gemeldeten Erkennung. Bei Unbekannten kommt hinzu, dass die Marke am
-            # einzelnen Treffer haengt — meldet ausgerechnet einer ohne Ausschnitt, bleibt
-            # die spaeter entstehende Zeile auf "nicht gemeldet". Beides betrifft nur die
-            # Marke und den angezeigten Wert, nie Meldung, Erkennung oder Ausschnitt, und
-            # waere nur mit mehr Zustand je Ereignis zu haben, als es kostet.
-            # (Fuer benannte Personen greift der Fall nicht: dort zaehlt announced, das
-            # unabhaengig vom Ausschnitt gesetzt wird.)
-            # Die vorhandene Zeile ist die Merkliste. Gibt es noch keine — oder wurde sie
-            # inzwischen vom Limit verdraengt (improve meldet das mit None) —, wird
-            # angelegt statt verbessert. Sonst fiele die Erkennung stillschweigend aus
-            # dem Verlauf, obwohl sie gemeldet wurde.
+            # Die Marke: bei benannten Personen traegt eine Zeile das ganze Ereignis, also
+            # zaehlt, ob dafuer irgendwann eine Meldung bestaetigt hinausging — sonst
+            # truege eine Zeile faelschlich "nicht gemeldet", wenn ausgerechnet der
+            # gemeldete Treffer keinen Ausschnitt hatte. Unbekannte behalten je Erkennung
+            # eine eigene Zeile (s. unten), dort zaehlt nur diese eine Meldung.
+            published = (sent if name == "unknown"
+                         else name in st.get("reported_names", ()))
+            # Bekannte Ungenauigkeit, bewusst so belassen: Eine Zeile, die nach einer
+            # Verdraengung neu entsteht, traegt den Wert der ausloesenden statt der
+            # gemeldeten Erkennung; und bei Unbekannten bleibt die Marke auf "nicht
+            # gemeldet", wenn der gemeldete Treffer keinen Ausschnitt hatte. Beides
+            # betrifft nur Marke und angezeigten Wert, nie Meldung, Erkennung oder
+            # Ausschnitt — und waere nur mit mehr Zustand je Ereignis zu haben, als es
+            # kostet.
+            #
+            # Gibt es noch keine Zeile — oder wurde sie vom Limit verdraengt, was improve
+            # mit None meldet —, wird angelegt statt verbessert. Sonst fiele die Erkennung
+            # stillschweigend aus dem Verlauf.
             hids = st.setdefault("hids", {})
             # "unknown" ist kein Name, sondern das Fehlen eines Namens: im Vollbild
             # koennen mehrere Fremde stehen, die alle so heissen. Sie zu einer Zeile

--- a/faceid-addon/config.yaml
+++ b/faceid-addon/config.yaml
@@ -1,5 +1,5 @@
 name: FaceID
-version: "0.22.1"
+version: "0.22.2"
 slug: faceid
 description: Face recognition for Frigate — trainable gallery, clustered unknown review, HA sensors
 url: https://github.com/SkyTechNerds/faceid

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -274,7 +274,7 @@ async function renderUnknowns(){
         <div class="tile">
           <img src="data/unknowns/${u.id}.jpg" loading="lazy">
           <span class="score">${(u.guess_score*100|0)}% · ${fmtWhen(u)}</span>
-          ${u.full_url?`<button class="z" title="full snapshot" onclick="showFull('${u.full_url}','${esc(u.camera||'')} · ${fmtWhen(u)}','data/unknowns/${u.id}.jpg')">⛶</button>`:''}
+          ${u.full_url?`<button class="z" title="full snapshot" data-url="${esc(u.full_url)}" data-cap="${esc(u.camera||'')} · ${esc(fmtWhen(u))}" data-fb="data/unknowns/${esc(u.id)}.jpg" onclick="showFull(this.dataset.url,this.dataset.cap,this.dataset.fb)">⛶</button>`:''}
           <button class="x" title="not ${esc(g.name)} — pull this face out" onclick="rejectSuggestion('${u.id}')">×</button>
         </div>`).join('')}
       </div>
@@ -300,7 +300,7 @@ async function renderUnknowns(){
         <div class="tile" data-id="${u.id}" title="click to select — actions then apply to the selection only" onclick="this.classList.toggle('sel')">
           <img src="data/unknowns/${u.id}.jpg" loading="lazy">
           <span class="score">${fmtWhen(u)}</span>
-          ${u.full_url?`<button class="z" title="full snapshot" onclick="event.stopPropagation();showFull('${u.full_url}','${esc(u.camera||'')} · ${fmtWhen(u)}','data/unknowns/${u.id}.jpg')">⛶</button>`:''}
+          ${u.full_url?`<button class="z" title="full snapshot" data-url="${esc(u.full_url)}" data-cap="${esc(u.camera||'')} · ${esc(fmtWhen(u))}" data-fb="data/unknowns/${esc(u.id)}.jpg" onclick="event.stopPropagation();showFull(this.dataset.url,this.dataset.cap,this.dataset.fb)">⛶</button>`:''}
         </div>`).join('')}
       </div>
     </div>`;}).join('');
@@ -509,7 +509,7 @@ async function renderHistory(){
     ${it.length?'':'<div class="stat" style="margin-top:8px">Nothing reported yet.</div>'}
     <div class="hgrid" style="margin-top:8px">${it.map(h=>`
       <div class="tile hcard">
-        <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" onclick="showFull(this.src,'${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
+        <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" data-cap="${esc(h.person)} ${esc(h.score)} · ${esc(h.camera||'')}" onclick="showFull(this.src,this.dataset.cap)" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
           ${h.reported===false?`<span class="sub" title="This recognition happened but could not be sent - the broker was unreachable. It is kept because the picture is what a wrong-recognition report needs.">not reported</span> `:''}<b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>
@@ -937,7 +937,7 @@ function personCard(slug,p){
       </div>
       <div class="grid">${p.files.map(f=>`
         <div class="tile" data-file="${f}"><img src="data/persons/${slug}/${f}" loading="lazy" style="cursor:zoom-in"
-            onclick="showFull('data/persons/${slug}/${f}','${esc(p.name)}')">
+            data-url="data/persons/${esc(slug)}/${esc(f)}" data-cap="${esc(p.name)}" onclick="showFull(this.dataset.url,this.dataset.cap)">
           <button class="u" title="back to unknown queue" onclick="unassignFace('${slug}','${f}')">↩</button>
           <button class="x" title="delete permanently" onclick="delFace('${slug}','${f}')">×</button></div>`).join('')}
       </div>

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -511,7 +511,7 @@ async function renderHistory(){
       <div class="tile hcard">
         <img src="data/history/${h.id}.jpg" loading="lazy" onclick="showFull('data/history/${h.id}.jpg','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
-          <b title="Reported as ${esc(h.person)} at ${h.score}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${h.best_score}), which is why it does not match the reported score`:''}">${esc(h.person)} ${h.score}${h.best_score?` <span class="sub">· best view ${h.best_score}</span>`:''}</b>
+          <b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>
           ${h.now?(h.now.self
             ? `<div class="nowis" title="You assigned this face to ${esc(h.now.person)}, so it is one of their reference photos now. It matches itself — that says nothing about how well ${esc(h.now.person)} is recognised.">now assigned: ${esc(h.now.person)}</div>`

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -509,7 +509,7 @@ async function renderHistory(){
     ${it.length?'':'<div class="stat" style="margin-top:8px">Nothing reported yet.</div>'}
     <div class="hgrid" style="margin-top:8px">${it.map(h=>`
       <div class="tile hcard">
-        <img src="data/history/${h.img||h.id+'.jpg'}" loading="lazy" onclick="showFull('data/history/${h.img||h.id+'.jpg'}','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
+        <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" onclick="showFull('data/history/${esc(h.img||h.id+'.jpg')}','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
           <b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -509,7 +509,7 @@ async function renderHistory(){
     ${it.length?'':'<div class="stat" style="margin-top:8px">Nothing reported yet.</div>'}
     <div class="hgrid" style="margin-top:8px">${it.map(h=>`
       <div class="tile hcard">
-        <img src="data/history/${h.id}.jpg" loading="lazy" onclick="showFull('data/history/${h.id}.jpg','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
+        <img src="data/history/${h.img||h.id+'.jpg'}" loading="lazy" onclick="showFull('data/history/${h.img||h.id+'.jpg'}','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
           <b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -511,7 +511,7 @@ async function renderHistory(){
       <div class="tile hcard">
         <img src="data/history/${h.id}.jpg" loading="lazy" onclick="showFull('data/history/${h.id}.jpg','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
-          <b title="${esc(h.person)} ${h.score}">${esc(h.person)} ${h.score}</b>
+          <b title="Reported as ${esc(h.person)} at ${h.score}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${h.best_score}), which is why it does not match the reported score`:''}">${esc(h.person)} ${h.score}${h.best_score?` <span class="sub">· best view ${h.best_score}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>
           ${h.now?(h.now.self
             ? `<div class="nowis" title="You assigned this face to ${esc(h.now.person)}, so it is one of their reference photos now. It matches itself — that says nothing about how well ${esc(h.now.person)} is recognised.">now assigned: ${esc(h.now.person)}</div>`

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -509,7 +509,7 @@ async function renderHistory(){
     ${it.length?'':'<div class="stat" style="margin-top:8px">Nothing reported yet.</div>'}
     <div class="hgrid" style="margin-top:8px">${it.map(h=>`
       <div class="tile hcard">
-        <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" onclick="showFull('data/history/${esc(h.img||h.id+'.jpg')}','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
+        <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" onclick="showFull(this.src,'${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
           ${h.reported===false?`<span class="sub" title="This recognition happened but could not be sent - the broker was unreachable. It is kept because the picture is what a wrong-recognition report needs.">not reported</span> `:''}<b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>

--- a/faceid-addon/static/index.html
+++ b/faceid-addon/static/index.html
@@ -511,7 +511,7 @@ async function renderHistory(){
       <div class="tile hcard">
         <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" onclick="showFull('data/history/${esc(h.img||h.id+'.jpg')}','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
-          <b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
+          ${h.reported===false?`<span class="sub" title="This recognition happened but could not be sent - the broker was unreachable. It is kept because the picture is what a wrong-recognition report needs.">not reported</span> `:''}<b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>
           ${h.now?(h.now.self
             ? `<div class="nowis" title="You assigned this face to ${esc(h.now.person)}, so it is one of their reference photos now. It matches itself — that says nothing about how well ${esc(h.now.person)} is recognised.">now assigned: ${esc(h.now.person)}</div>`

--- a/static/index.html
+++ b/static/index.html
@@ -274,7 +274,7 @@ async function renderUnknowns(){
         <div class="tile">
           <img src="data/unknowns/${u.id}.jpg" loading="lazy">
           <span class="score">${(u.guess_score*100|0)}% · ${fmtWhen(u)}</span>
-          ${u.full_url?`<button class="z" title="full snapshot" onclick="showFull('${u.full_url}','${esc(u.camera||'')} · ${fmtWhen(u)}','data/unknowns/${u.id}.jpg')">⛶</button>`:''}
+          ${u.full_url?`<button class="z" title="full snapshot" data-url="${esc(u.full_url)}" data-cap="${esc(u.camera||'')} · ${esc(fmtWhen(u))}" data-fb="data/unknowns/${esc(u.id)}.jpg" onclick="showFull(this.dataset.url,this.dataset.cap,this.dataset.fb)">⛶</button>`:''}
           <button class="x" title="not ${esc(g.name)} — pull this face out" onclick="rejectSuggestion('${u.id}')">×</button>
         </div>`).join('')}
       </div>
@@ -300,7 +300,7 @@ async function renderUnknowns(){
         <div class="tile" data-id="${u.id}" title="click to select — actions then apply to the selection only" onclick="this.classList.toggle('sel')">
           <img src="data/unknowns/${u.id}.jpg" loading="lazy">
           <span class="score">${fmtWhen(u)}</span>
-          ${u.full_url?`<button class="z" title="full snapshot" onclick="event.stopPropagation();showFull('${u.full_url}','${esc(u.camera||'')} · ${fmtWhen(u)}','data/unknowns/${u.id}.jpg')">⛶</button>`:''}
+          ${u.full_url?`<button class="z" title="full snapshot" data-url="${esc(u.full_url)}" data-cap="${esc(u.camera||'')} · ${esc(fmtWhen(u))}" data-fb="data/unknowns/${esc(u.id)}.jpg" onclick="event.stopPropagation();showFull(this.dataset.url,this.dataset.cap,this.dataset.fb)">⛶</button>`:''}
         </div>`).join('')}
       </div>
     </div>`;}).join('');
@@ -509,7 +509,7 @@ async function renderHistory(){
     ${it.length?'':'<div class="stat" style="margin-top:8px">Nothing reported yet.</div>'}
     <div class="hgrid" style="margin-top:8px">${it.map(h=>`
       <div class="tile hcard">
-        <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" onclick="showFull(this.src,'${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
+        <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" data-cap="${esc(h.person)} ${esc(h.score)} · ${esc(h.camera||'')}" onclick="showFull(this.src,this.dataset.cap)" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
           ${h.reported===false?`<span class="sub" title="This recognition happened but could not be sent - the broker was unreachable. It is kept because the picture is what a wrong-recognition report needs.">not reported</span> `:''}<b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>
@@ -937,7 +937,7 @@ function personCard(slug,p){
       </div>
       <div class="grid">${p.files.map(f=>`
         <div class="tile" data-file="${f}"><img src="data/persons/${slug}/${f}" loading="lazy" style="cursor:zoom-in"
-            onclick="showFull('data/persons/${slug}/${f}','${esc(p.name)}')">
+            data-url="data/persons/${esc(slug)}/${esc(f)}" data-cap="${esc(p.name)}" onclick="showFull(this.dataset.url,this.dataset.cap)">
           <button class="u" title="back to unknown queue" onclick="unassignFace('${slug}','${f}')">↩</button>
           <button class="x" title="delete permanently" onclick="delFace('${slug}','${f}')">×</button></div>`).join('')}
       </div>

--- a/static/index.html
+++ b/static/index.html
@@ -511,7 +511,7 @@ async function renderHistory(){
       <div class="tile hcard">
         <img src="data/history/${h.id}.jpg" loading="lazy" onclick="showFull('data/history/${h.id}.jpg','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
-          <b title="Reported as ${esc(h.person)} at ${h.score}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${h.best_score}), which is why it does not match the reported score`:''}">${esc(h.person)} ${h.score}${h.best_score?` <span class="sub">· best view ${h.best_score}</span>`:''}</b>
+          <b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>
           ${h.now?(h.now.self
             ? `<div class="nowis" title="You assigned this face to ${esc(h.now.person)}, so it is one of their reference photos now. It matches itself — that says nothing about how well ${esc(h.now.person)} is recognised.">now assigned: ${esc(h.now.person)}</div>`

--- a/static/index.html
+++ b/static/index.html
@@ -509,7 +509,7 @@ async function renderHistory(){
     ${it.length?'':'<div class="stat" style="margin-top:8px">Nothing reported yet.</div>'}
     <div class="hgrid" style="margin-top:8px">${it.map(h=>`
       <div class="tile hcard">
-        <img src="data/history/${h.img||h.id+'.jpg'}" loading="lazy" onclick="showFull('data/history/${h.img||h.id+'.jpg'}','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
+        <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" onclick="showFull('data/history/${esc(h.img||h.id+'.jpg')}','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
           <b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>

--- a/static/index.html
+++ b/static/index.html
@@ -509,7 +509,7 @@ async function renderHistory(){
     ${it.length?'':'<div class="stat" style="margin-top:8px">Nothing reported yet.</div>'}
     <div class="hgrid" style="margin-top:8px">${it.map(h=>`
       <div class="tile hcard">
-        <img src="data/history/${h.id}.jpg" loading="lazy" onclick="showFull('data/history/${h.id}.jpg','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
+        <img src="data/history/${h.img||h.id+'.jpg'}" loading="lazy" onclick="showFull('data/history/${h.img||h.id+'.jpg'}','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
           <b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>

--- a/static/index.html
+++ b/static/index.html
@@ -511,7 +511,7 @@ async function renderHistory(){
       <div class="tile hcard">
         <img src="data/history/${h.id}.jpg" loading="lazy" onclick="showFull('data/history/${h.id}.jpg','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
-          <b title="${esc(h.person)} ${h.score}">${esc(h.person)} ${h.score}</b>
+          <b title="Reported as ${esc(h.person)} at ${h.score}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${h.best_score}), which is why it does not match the reported score`:''}">${esc(h.person)} ${h.score}${h.best_score?` <span class="sub">· best view ${h.best_score}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>
           ${h.now?(h.now.self
             ? `<div class="nowis" title="You assigned this face to ${esc(h.now.person)}, so it is one of their reference photos now. It matches itself — that says nothing about how well ${esc(h.now.person)} is recognised.">now assigned: ${esc(h.now.person)}</div>`

--- a/static/index.html
+++ b/static/index.html
@@ -509,7 +509,7 @@ async function renderHistory(){
     ${it.length?'':'<div class="stat" style="margin-top:8px">Nothing reported yet.</div>'}
     <div class="hgrid" style="margin-top:8px">${it.map(h=>`
       <div class="tile hcard">
-        <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" onclick="showFull('data/history/${esc(h.img||h.id+'.jpg')}','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
+        <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" onclick="showFull(this.src,'${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
           ${h.reported===false?`<span class="sub" title="This recognition happened but could not be sent - the broker was unreachable. It is kept because the picture is what a wrong-recognition report needs.">not reported</span> `:''}<b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>

--- a/static/index.html
+++ b/static/index.html
@@ -511,7 +511,7 @@ async function renderHistory(){
       <div class="tile hcard">
         <img src="data/history/${esc(h.img||h.id+'.jpg')}" loading="lazy" onclick="showFull('data/history/${esc(h.img||h.id+'.jpg')}','${esc(h.person)} ${h.score} · ${esc(h.camera||'')}')" title="${esc(h.person)} ${h.score} on ${esc(h.camera||'')}${h.zones&&h.zones.length?' · '+esc(h.zones.join(', ')):''}">
         <div class="meta">
-          <b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
+          ${h.reported===false?`<span class="sub" title="This recognition happened but could not be sent - the broker was unreachable. It is kept because the picture is what a wrong-recognition report needs.">not reported</span> `:''}<b title="Reported as ${esc(h.person)} at ${esc(h.score)}${h.best_score?` — the picture shown is a later, clearer view of the same person from the same event (${esc(h.best_score)}), which is why it does not match the reported score`:''}">${esc(h.person)} ${esc(h.score)}${h.best_score?` <span class="sub">· best view ${esc(h.best_score)}</span>`:''}</b>
           <span class="sub">${fmtTs(h.ts)} · ${esc(h.camera||'')}</span>
           ${h.now?(h.now.self
             ? `<div class="nowis" title="You assigned this face to ${esc(h.now.person)}, so it is one of their reference photos now. It matches itself — that says nothing about how well ${esc(h.now.person)} is recognised.">now assigned: ${esc(h.now.person)}</div>`


### PR DESCRIPTION
Follow-up to the observation parked in #17.

**The problem is not duplication, it is a false claim.** The tab is titled *"What FaceID reported"*, but only the first match per person and event is reported — the `announced` set suppresses every later `faceid/event`. Additional rows therefore assert a notification that never happened, and someone seeing two rows concludes they were notified twice.

They also cost range. Measured on the live instance:

| | |
|---|---|
| history | 200 entries (full, `history_keep: 200`) |
| extra rows | 27 across 24 pairs = **13.5%** |
| scores identical | 1 of 24 |
| gap between rows | 1.4 s to 25 s, different attempts |

**Dropping the later matches would have been the wrong fix.** I checked the stored crops before deciding: **all ten sampled pairs hold different pictures**, sometimes drastically — `8 KB` against `94 KB` of the same person, a distant crop against a close one. Those later pictures are what make a wrong recognition checkable at all.

So a later match now **improves the existing row** instead of adding one: the picture is replaced only when its score is higher, and the card shows `best view 0.687` next to the reported score. The reported score and timestamp stay, so the history still answers what actually triggered the notification.

Picture and embedding are replaced **together** — separating them would be the real bug, letting the "was wrong" analysis run on a different face than the row shows.

**Tested** against a temporary directory rather than the live history:

```
nach add               score=0.489 best=None          jpg=691B    emb0=0.044248
improve 0.400 (lower)  -> False    unchanged
improve 0.687 (higher) -> True     score=0.489 best=0.687 best_attempt=5 jpg=34462B emb0=0.0
improve 0.500 (< best) -> False    unchanged
rows in history: 1
```

Note the third case: a later match is compared against `best_score`, not against the reported score, so the best picture cannot be replaced by a mediocre one.

Existing duplicate rows are left alone — they hold real pictures, and deleting user-visible data is not something a release should do silently.